### PR TITLE
Enable SSE and SSE2 instructions in 32-bit build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,9 @@
 {
+  "target_defaults": {
+    "target_conditions": [
+      ["OS != 'win'", {"cflags": ["-msse","-msse2"]}]
+    ]
+  },
   "targets": [
     {
       "target_name": "libargon2",


### PR DESCRIPTION
Compiling with gcc for x86_64 enables -msse and -msse2 by default, but
x86 does not. The optimized argon2 build requires SSE2, and can benefit
from SSE3.

The optimized argon2 build specifies -march=native in its makefile to
enable the highest supported instruction set. The downside is that
binaries built on newer machines may not work on older machines.

For the moment, enabling the absolute minimum seems like the safest
option.

Fixes #5