### PR TITLE
Tighten parameter checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ var validate = function (salt, options, callback) {
   }
 
   if (options.memoryCost >= 32) {
-    fail("Memory cost too high, maximum of 32.", callback);
+    fail("Memory cost too high, maximum of 31.", callback);
     return false;
   }
 

--- a/index.js
+++ b/index.js
@@ -33,8 +33,23 @@ var validate = function (salt, options, callback) {
     return false;
   }
 
+  if (options.timeCost < 0) {
+    fail("Time cost must be positive.", callback);
+    return false;
+  }
+
+  if (options.timeCost >= 4294967296) {
+    fail("Time cost too high, maximum of 4294967295.", callback);
+    return false;
+  }
+
   if (isNaN(options.memoryCost)) {
     fail("Invalid memory cost, must be a number.", callback);
+    return false;
+  }
+
+  if (options.memoryCost < 0) {
+    fail("Memory cost must be positive.", callback);
     return false;
   }
 
@@ -45,6 +60,16 @@ var validate = function (salt, options, callback) {
 
   if (isNaN(options.parallelism)) {
     fail("Invalid parallelism, must be a number.", callback);
+    return false;
+  }
+
+  if (options.parallelism < 0) {
+    fail("Parallelism must be positive.", callback);
+    return false;
+  }
+
+  if (options.parallelism >= 4294967296) {
+    fail("Parallelism too high.", callback);
     return false;
   }
 

--- a/src/argon2_node.cpp
+++ b/src/argon2_node.cpp
@@ -104,6 +104,8 @@ NAN_METHOD(Hash) {
 }
 
 NAN_METHOD(HashSync) {
+    using std::strlen;
+
     Nan::HandleScope scope;
 
     if (info.Length() < 6) {
@@ -136,7 +138,7 @@ NAN_METHOD(HashSync) {
         return;
     }
 
-    info.GetReturnValue().Set(Nan::Encode(encoded, std::strlen(encoded),
+    info.GetReturnValue().Set(Nan::Encode(encoded, strlen(encoded),
             Nan::BINARY));
 }
 

--- a/src/argon2_node.cpp
+++ b/src/argon2_node.cpp
@@ -51,7 +51,8 @@ void HashAsyncWorker::Execute()
             plain.c_str(), plain.size(), salt.c_str(), salt.size(), nullptr,
             HASH_LEN, encoded, ENCODED_LEN, type);
     if (result != ARGON2_OK) {
-        return; // LCOV_EXCL_LINE
+        SetErrorMessage(error_message(result));
+        return;
     }
 
     output = std::string{encoded};
@@ -129,10 +130,9 @@ NAN_METHOD(HashSync) {
             encoded, ENCODED_LEN, type);
 
     if (result != ARGON2_OK) {
-        /* LCOV_EXCL_START */
+        Nan::ThrowError(error_message(result));
         info.GetReturnValue().Set(Nan::Undefined());
         return;
-        /* LCOV_EXCL_STOP */
     }
 
     info.GetReturnValue().Set(Nan::Encode(encoded, std::strlen(encoded),

--- a/src/argon2_node.cpp
+++ b/src/argon2_node.cpp
@@ -1,6 +1,7 @@
 #include <nan.h>
 #include <node.h>
 
+#include <cstdint>
 #include <cstring>
 #include <string>
 
@@ -8,7 +9,7 @@
 
 namespace {
 
-using uint = unsigned int;
+using std::uint32_t;
 
 const auto ENCODED_LEN = 108u;
 const auto HASH_LEN = 32u;
@@ -17,8 +18,8 @@ const auto SALT_LEN = 16u;
 class HashAsyncWorker : public Nan::AsyncWorker {
 public:
     HashAsyncWorker(Nan::Callback* callback, const std::string& plain,
-            const std::string& salt, uint time_cost, uint memory_cost,
-            uint parallelism, argon2_type type);
+            const std::string& salt, uint32_t time_cost, uint32_t memory_cost,
+            uint32_t parallelism, argon2_type type);
 
     void Execute();
 
@@ -27,17 +28,17 @@ public:
 private:
     std::string plain;
     std::string salt;
-    uint time_cost;
-    uint memory_cost;
-    uint parallelism;
+    uint32_t time_cost;
+    uint32_t memory_cost;
+    uint32_t parallelism;
     std::string error;
     Argon2_type type;
     std::string output;
 };
 
 HashAsyncWorker::HashAsyncWorker(Nan::Callback* callback,
-        const std::string& plain, const std::string& salt, uint time_cost,
-        uint memory_cost, uint parallelism, Argon2_type type):
+        const std::string& plain, const std::string& salt, uint32_t time_cost,
+        uint32_t memory_cost, uint32_t parallelism, Argon2_type type):
     Nan::AsyncWorker(callback), plain{plain}, salt{salt}, time_cost{time_cost},
     memory_cost{memory_cost}, parallelism{parallelism}, error{}, type{type},
     output{}

--- a/test.spec.js
+++ b/test.spec.js
@@ -118,6 +118,36 @@ module.exports = {
     });
   },
 
+  test_hash_negative_time_cost: function (assert) {
+    "use strict";
+
+    assert.expect(3);
+
+    argon2.hash("password", "somesalt", {
+      timeCost: -4294967290
+    }, function (err, hash) {
+      assert.ok(err, "Error should be defined.");
+      assert.equal(err.message, "Time cost must be positive.");
+      assert.equal(undefined, hash);
+      assert.done();
+    });
+  },
+
+  test_hash_high_time_cost: function (assert) {
+    "use strict";
+
+    assert.expect(3);
+
+    argon2.hash("password", "somesalt", {
+      timeCost: 4294967297
+    }, function (err, hash) {
+      assert.ok(err, "Error should be defined.");
+      assert.equal(err.message, "Time cost too high, maximum of 4294967295.");
+      assert.equal(undefined, hash);
+      assert.done();
+    });
+  },
+
   test_hash_memory_cost: function (assert) {
     "use strict";
 
@@ -143,6 +173,21 @@ module.exports = {
     }, function (err, hash) {
       assert.ok(err, "Error should be defined.");
       assert.equal(err.message, "Invalid memory cost, must be a number.");
+      assert.equal(undefined, hash);
+      assert.done();
+    });
+  },
+
+  test_hash_negative_memory_cost: function (assert) {
+    "use strict";
+
+    assert.expect(3);
+
+    argon2.hash("password", "somesalt", {
+      memoryCost: -4294967290
+    }, function (err, hash) {
+      assert.ok(err, "Error should be defined.");
+      assert.equal(err.message, "Memory cost must be positive.");
       assert.equal(undefined, hash);
       assert.done();
     });
@@ -188,6 +233,36 @@ module.exports = {
     }, function (err, hash) {
       assert.ok(err, "Error should be defined.");
       assert.equal(err.message, "Invalid parallelism, must be a number.");
+      assert.equal(undefined, hash);
+      assert.done();
+    });
+  },
+
+  test_hash_negative_parallelism: function (assert) {
+    "use strict";
+
+    assert.expect(3);
+
+    argon2.hash("password", "somesalt", {
+      parallelism: -4294967290
+    }, function (err, hash) {
+      assert.ok(err, "Error should be defined.");
+      assert.equal(err.message, "Parallelism must be positive.");
+      assert.equal(undefined, hash);
+      assert.done();
+    });
+  },
+
+  test_hash_high_parallelism: function (assert) {
+    "use strict";
+
+    assert.expect(3);
+
+    argon2.hash("password", "somesalt", {
+      parallelism: 4294967297
+    }, function (err, hash) {
+      assert.ok(err, "Error should be defined.");
+      assert.equal(err.message, "Parallelism too high.");
       assert.equal(undefined, hash);
       assert.done();
     });

--- a/test.spec.js
+++ b/test.spec.js
@@ -133,6 +133,21 @@ module.exports = {
     });
   },
 
+  test_hash_low_time_cost: function (assert) {
+    "use strict";
+
+    assert.expect(3);
+
+    argon2.hash("password", "somesalt", {
+      timeCost: 0
+    }, function (err, hash) {
+      assert.ok(err, "Error should be defined.");
+      assert.equal(err.message, "Time cost is too small");
+      assert.equal(undefined, hash);
+      assert.done();
+    });
+  },
+
   test_hash_high_time_cost: function (assert) {
     "use strict";
 
@@ -353,6 +368,19 @@ module.exports = {
         timeCost: "foo"
       });
     });
+    assert.done();
+  },
+
+  test_hash_sync_low_time_cost: function (assert) {
+    "use strict";
+
+    assert.expect(1);
+
+    assert.throws(function () {
+      var hash = argon2.hashSync("password", "somesalt", {
+        timeCost: 0
+      });
+    }, /Time cost is too small/);
     assert.done();
   },
 

--- a/test.spec.js
+++ b/test.spec.js
@@ -157,7 +157,7 @@ module.exports = {
       memoryCost: 32
     }, function (err, hash) {
       assert.ok(err, "Error should be defined.");
-      assert.equal(err.message, "Memory cost too high, maximum of 32.");
+      assert.equal(err.message, "Memory cost too high, maximum of 31.");
       assert.equal(undefined, hash);
       assert.done();
     });

--- a/test.spec.js
+++ b/test.spec.js
@@ -384,6 +384,32 @@ module.exports = {
     assert.done();
   },
 
+  test_hash_sync_negative_time_cost: function (assert) {
+    "use strict";
+
+    assert.expect(1);
+
+    assert.throws(function () {
+      var hash = argon2.hashSync("password", "somesalt", {
+        timeCost: -4294967290
+      });
+    }, /Time cost must be positive/);
+    assert.done();
+  },
+
+  test_hash_sync_high_time_cost: function (assert) {
+    "use strict";
+
+    assert.expect(1);
+
+    assert.throws(function () {
+      var hash = argon2.hashSync("password", "somesalt", {
+        timeCost: 4294967297
+      });
+    }, /Time cost too high, maximum of 4294967295/);
+    assert.done();
+  },
+
   test_hash_sync_memory_cost: function (assert) {
     "use strict";
 
@@ -406,6 +432,19 @@ module.exports = {
         memoryCost: "foo"
       });
     });
+    assert.done();
+  },
+
+  test_hash_sync_negative_memory_cost: function (assert) {
+    "use strict";
+
+    assert.expect(1);
+
+    assert.throws(function () {
+      var hash = argon2.hashSync("password", "somesalt", {
+        memoryCost: -4294967290
+      });
+    }, /Memory cost must be positive/);
     assert.done();
   },
 
@@ -444,6 +483,32 @@ module.exports = {
         parallelism: "foo"
       });
     });
+    assert.done();
+  },
+
+  test_hash_sync_negative_parallelism: function (assert) {
+    "use strict";
+
+    assert.expect(1);
+
+    assert.throws(function () {
+      var hash = argon2.hashSync("password", "somesalt", {
+        parallelism: -4294967290
+      });
+    }, /Parallelism must be positive/);
+    assert.done();
+  },
+
+  test_hash_sync_high_parallelism: function (assert) {
+    "use strict";
+
+    assert.expect(1);
+
+    assert.throws(function () {
+      var hash = argon2.hashSync("password", "somesalt", {
+        parallelism: 4294967297
+      });
+    }, /Parallelism too high/);
     assert.done();
   },
 


### PR DESCRIPTION
When I first starting using node-argon2, I noticed a couple issues. It turned out that you fixed them (98d639ca14818d8514b39428f2f38f7aca65c6e8, a604e2a3c30a785e13309ffaa8590c5a22acad89) before I even got a chance to file an issue, but I decided nevertheless to review the node-argon2 source to see if I could spot any further problems.

The good news is, I didn't find anything particularly worrisome. Most of the problems I found were around edge cases that I'd probably never encounter. Nevertheless, they should be fixed.

This pull request tightens up the validation done on parameters.

1. The maximum memory cost is reported as 32, but supplying the value 32 is an error. I've reduced the reported maximum to 31.

2. Input values are not checked for overflow. This means that if you supply a ridiculously large cost for your hash, node-argon2 could possibly create a hash with a very small cost. I'm not sure if supplying such a ridiculously large cost actually makes any sense, but node-argon2 should always either do the right thing or return an error.

3. Negative input values are also accepted. If these negative values are large enough, they might be accepted without error as positive values. node-argon2 should probably just return an error when supplied with negative parameter values.

4. libargon2 could fail to hash for many reasons. For example, by providing a time cost that is too small. No error is reported by node-argon2 when this occurred. The hash would just be undefined. I've changed this to relay the error.