### PR TITLE
Improve bad salt handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,14 +99,14 @@ exports.generateSalt = function (callback) {
   'use strict';
 
   crypto.randomBytes(16, function (err, buffer) {
-    callback(err, buffer.toString());
+    callback(err, buffer.toString('ascii'));
   });
 };
 
 exports.generateSaltSync = function () {
   'use strict';
 
-  return crypto.randomBytes(16).toString();
+  return crypto.randomBytes(16).toString('ascii');
 };
 
 exports.verify = function (hash, plain, callback) {

--- a/src/argon2_node.cpp
+++ b/src/argon2_node.cpp
@@ -94,7 +94,7 @@ NAN_METHOD(Hash) {
     argon2_type type = info[5]->BooleanValue() ? Argon2_d : Argon2_i;
     Local<Function> callback = Local<Function>::Cast(info[6]);
 
-    auto salt = std::string{*raw_salt};
+    auto salt = std::string{*raw_salt, raw_salt.length()};
     salt.resize(SALT_LEN, 0x0);
 
     auto worker = new HashAsyncWorker(new Nan::Callback(callback), *plain, salt,
@@ -125,7 +125,7 @@ NAN_METHOD(HashSync) {
 
     char encoded[ENCODED_LEN];
 
-    auto salt = std::string{*raw_salt};
+    auto salt = std::string{*raw_salt, raw_salt.length()};
     salt.resize(SALT_LEN, 0x0);
 
     auto result = argon2_hash(time_cost, 1 << memory_cost, parallelism, *plain,


### PR DESCRIPTION
Node's Buffer::toString interprets the data as UTF-8 by default. This
results in decoding errors when trying to convert the random bytes to
string, because some byte sequences are not valid unicode. The
replacement of invalid unicode with the Unicode Replacement Character
(U+FFFD) greatly decreases the entropy of the string and significantly
lengthens its representation in bytes. The later truncation of the
string to 16 bytes then further decreases its entropy.

Specifying that the string is ascii reduces entropy somewhat, as null
bytes are converted to spaces, and the high bit is stripped from each
byte. This is still better than the utf-8 errors, but not perfect.

Specifying the string as binary, unfortunately, results in a longer
representation when finally converted back to UTF-8 for hashing. There
may be a way to handle this in the C++ code, but it's unclear how you'd
identify the encoding given that we can't depend on the salt coming
from our own code.

Within the hash function itself, the use of std::strlen for determining
the length of the salt is inappropriate, as completely random strings
may contain null bytes.

There is a real question as to whether the password or the salt should
actually even be strings, but that can't be changed without breaking
backwards compatibility. Ideally, we'd just keep everything in byte
buffers and not worry about string encodings at all.

**Please do not accept this pull request without an independent
technical review**. I'm confident that it's an improvement, but there may
be better options. I just want to present this as part of a discussion about
how to address these issues.