### PR TITLE
Fix bad salt behavior with buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,10 @@ var validate = function (salt, options, callback) {
 exports.hash = function (plain, salt, options, callback) {
   'use strict';
 
+  if (!Buffer.isBuffer(salt)) {
+    salt = new Buffer(salt);
+  }
+
   if (!callback) {
     callback = options;
     options = defaults;
@@ -87,6 +91,10 @@ exports.hash = function (plain, salt, options, callback) {
 exports.hashSync = function (plain, salt, options) {
   'use strict';
 
+  if (!Buffer.isBuffer(salt)) {
+    salt = new Buffer(salt);
+  }
+
   options = Object.assign({}, options || defaults);
 
   if (validate(salt, options)) {
@@ -99,14 +107,14 @@ exports.generateSalt = function (callback) {
   'use strict';
 
   crypto.randomBytes(16, function (err, buffer) {
-    callback(err, buffer.toString());
+    callback(err, buffer);
   });
 };
 
 exports.generateSaltSync = function () {
   'use strict';
 
-  return crypto.randomBytes(16).toString();
+  return crypto.randomBytes(16);
 };
 
 exports.verify = function (hash, plain, callback) {


### PR DESCRIPTION
Fixes `generateSalt*` and `hash*` functions to use buffer salts instead of strings, and thus prevent a `0x00` byte to be interpreted as a null-termination of a char* string. Internally, `std::string` may have `0x00`, so this is not an issue on the C++ side.

@cgmb could you please apply your tests on this solution?