### PR TITLE
Use stdint.h from C99

### DIFF
--- a/src/argon2_node.cpp
+++ b/src/argon2_node.cpp
@@ -1,15 +1,14 @@
 #include <nan.h>
 #include <node.h>
 
-#include <cstdint>
+#include <stdint.h>
+
 #include <cstring>
 #include <string>
 
 #include "../argon2/include/argon2.h"
 
 namespace {
-
-using std::uint32_t;
 
 const auto ENCODED_LEN = 108u;
 const auto HASH_LEN = 32u;


### PR DESCRIPTION
The default OSX build flags include -mmacosx-version-min=10.5
which limits our C++11 support. uint32_t is part of the argon2
interface, so we can always rely on it being available.