### PR TITLE
Use buffers for passwords

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,10 @@ module.exports = {
 
     options = Object.assign({}, defaults, options);
 
+    if (!Buffer.isBuffer(plain)) {
+      plain = new Buffer(plain);
+    }
+
     return new Promise(validate.bind(this, salt, options))
       .then(() => bindings.hash(plain, salt, options.timeCost,
           options.memoryCost, options.parallelism, options.argon2d));
@@ -66,6 +70,10 @@ module.exports = {
 
     console.warn('The synchronous API is deprecated, use ES6 await instead.');
     options = Object.assign({}, defaults, options);
+
+    if (!Buffer.isBuffer(plain)) {
+      plain = new Buffer(plain);
+    }
 
     if (validate(salt, options)) {
       return bindings.hashSync(plain, salt, options.timeCost,
@@ -99,6 +107,10 @@ module.exports = {
   verify (hash, plain) {
     'use strict';
 
+    if (!Buffer.isBuffer(plain)) {
+      plain = new Buffer(plain);
+    }
+
     return bindings.verify(hash, plain, /argon2d/.test(hash));
   },
 
@@ -106,6 +118,11 @@ module.exports = {
     'use strict';
 
     console.warn('The synchronous API is deprecated, use ES6 await instead.');
+
+    if (!Buffer.isBuffer(plain)) {
+      plain = new Buffer(plain);
+    }
+
     return bindings.verifySync(hash, plain, /argon2d/.test(hash));
   }
 };

--- a/test.spec.js
+++ b/test.spec.js
@@ -29,6 +29,16 @@ t.test('basic async hash', t => {
   });
 }).catch(t.threw);
 
+t.test('async hash with null in password', t => {
+  'use strict';
+
+  t.plan(1);
+
+  return argon2.hash('pass\0word', salt).then(hash => {
+    t.equal(hash, '$argon2i$m=4096,t=3,p=1$c29tZXNhbHQ$tcauj48oAe6NE/VLzTawLTQtmX848wkNs1d7z53ahNE');
+  });
+}).catch(t.threw);
+
 t.test('async hash with argon2d', t => {
   'use strict';
 
@@ -248,6 +258,14 @@ t.test('basic sync hash', t => {
 
   const hash = argon2.hashSync(password, salt);
   t.equal(hash, '$argon2i$m=4096,t=3,p=1$c29tZXNhbHQ$vpOd0mbc3AzXEHMgcTb1CrZt5XuoRQuz1kQtGBv7ejk');
+  t.end();
+});
+
+t.test('sync hash with null in password', t => {
+  'use strict';
+
+  const hash = argon2.hashSync('pass\0word', salt);
+  t.equal(hash, '$argon2i$m=4096,t=3,p=1$c29tZXNhbHQ$tcauj48oAe6NE/VLzTawLTQtmX848wkNs1d7z53ahNE');
   t.end();
 });
 
@@ -494,6 +512,16 @@ t.test('async verify wrong password', t => {
   });
 }).catch(t.threw);
 
+t.test('async verify with null in password', t => {
+  'use strict';
+
+  return argon2.generateSalt().then(salt => {
+    return argon2.hash('pass\0word', salt).then(hash => {
+      return argon2.verify(hash, 'pass\0word').then(t.pass);
+    });
+  });
+}).catch(t.threw);
+
 t.test('async verify argon2d correct password', t => {
   'use strict';
 
@@ -538,6 +566,18 @@ t.test('sync verify wrong password', t => {
   return argon2.generateSalt().then(salt => {
     return argon2.hash(password, salt).then(hash => {
       t.false(argon2.verifySync(hash, 'passworld'));
+    });
+  });
+}).catch(t.threw);
+
+t.test('sync verify with null in password', t => {
+  'use strict';
+
+  t.plan(1);
+
+  return argon2.generateSalt().then(salt => {
+    return argon2.hash('pass\0word', salt).then(hash => {
+      t.true(argon2.verifySync(hash, 'pass\0word'));
     });
   });
 }).catch(t.threw);

--- a/test.spec.js
+++ b/test.spec.js
@@ -3,9 +3,13 @@ const t = require('tap');
 
 const password = 'password';
 const salt = new Buffer('somesalt');
-
 const saltWithNull = new Buffer('\0abcdefghijklmno');
-const saltWithNullBase64 = 'AGFiY2RlZmdoaWprbG1ubw';
+
+// Like argon2's modified base64 implementation, this function truncates any
+// trailing '=' characters for a more compact representation.
+const truncatedBase64 = (buffer) => {
+  return buffer.toString('base64').replace(/=?=?$/,'');
+}
 
 const limits = argon2.limits;
 console.warn = () => {};
@@ -49,7 +53,7 @@ t.test('async hash with null in salt', t => {
 
   return argon2.hash(password, saltWithNull).then(hash => {
     const saltBase64 = hash.substring(24, 46);
-    t.equal(saltBase64, saltWithNullBase64);
+    t.equal(saltBase64, truncatedBase64(saltWithNull));
   });
 }).catch(t.threw);
 
@@ -288,7 +292,7 @@ t.test('sync hash with null in salt', t => {
 
   const hash = argon2.hashSync(password, saltWithNull);
   const saltBase64 = hash.substring(24, 46);
-  t.equal(saltBase64, saltWithNullBase64);
+  t.equal(saltBase64, truncatedBase64(saltWithNull));
   t.end();
 });
 

--- a/test.spec.js
+++ b/test.spec.js
@@ -4,6 +4,9 @@ const t = require('tap');
 const password = 'password';
 const salt = new Buffer('somesalt');
 
+const saltWithNull = new Buffer('\0abcdefghijklmno');
+const saltWithNullBase64 = 'AGFiY2RlZmdoaWprbG1ubw';
+
 const limits = argon2.limits;
 console.warn = () => {};
 
@@ -36,6 +39,17 @@ t.test('async hash with null in password', t => {
 
   return argon2.hash('pass\0word', salt).then(hash => {
     t.equal(hash, '$argon2i$m=4096,t=3,p=1$c29tZXNhbHQ$tcauj48oAe6NE/VLzTawLTQtmX848wkNs1d7z53ahNE');
+  });
+}).catch(t.threw);
+
+t.test('async hash with null in salt', t => {
+  'use strict';
+
+  t.plan(1);
+
+  return argon2.hash(password, saltWithNull).then(hash => {
+    const saltBase64 = hash.substring(24, 46);
+    t.equal(saltBase64, saltWithNullBase64);
   });
 }).catch(t.threw);
 
@@ -266,6 +280,15 @@ t.test('sync hash with null in password', t => {
 
   const hash = argon2.hashSync('pass\0word', salt);
   t.equal(hash, '$argon2i$m=4096,t=3,p=1$c29tZXNhbHQ$tcauj48oAe6NE/VLzTawLTQtmX848wkNs1d7z53ahNE');
+  t.end();
+});
+
+t.test('sync hash with null in salt', t => {
+  'use strict';
+
+  const hash = argon2.hashSync(password, saltWithNull);
+  const saltBase64 = hash.substring(24, 46);
+  t.equal(saltBase64, saltWithNullBase64);
   t.end();
 });
 


### PR DESCRIPTION
`node-argon2` currently uses null-terminated UTF-8 strings for passwords. I think that using byte buffers may be preferable. It only makes a difference in some unusual cases, but it ensures that users of node-argon2 can verify _any_ password that was hashed by argon2.

For example, consider a user who originally wrote their app in another language. Let's say they used UTF-16 encoding for passwords passed to argon2. When they later switched to node, the ability to use byte buffers would make the transition easy. As it stands, I think it would be impossible. Of course, this is a hypothetical. Maybe I'm missing something.

As you showed in a previous patch for the salt, it's easy to convert strings to buffers in JavaScript, making this change almost invisible to users passing strings. The only visible changes in behaviour would be for passwords with embedded null characters, where we would now consider the whole string. However, that seems rather unusual and it would be pretty easy for a library user to truncate the passwords themselves, if they had to.