### PR TITLE
Explicitly set the compiler to use C++11

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -37,6 +37,20 @@
         "argon2/include"
       ],
       "dependencies": ["libargon2"],
+      "cflags": ["-std=c++11", "-stdlib=libc++"],
+      "conditions": [
+        [ "OS != 'win'", {
+          "cflags+": [ "-std=c++11" ],
+          "cflags_c+": [ "-std=c++11" ],
+          "cflags_cc+": [ "-std=c++11" ],
+        }],
+        [ "OS == 'mac'", {
+          "xcode_settings": {
+            "OTHER_CPLUSPLUSFLAGS" : [ "-std=c++11", "-stdlib=libc++" ],
+            "OTHER_LDFLAGS": [ "-stdlib=libc++" ]
+          }
+        }]
+      ],
       "configurations": {
         "Debug": {
           "conditions": [


### PR DESCRIPTION
C++11 or greater may not be the default on all systems, but is required
by the argon2_node library.

This sets the appropriate flags for various compilers/environments.

This fixes Issue #49.