### PR TITLE
Fixed build errors on Windows

### DIFF
--- a/src/argon2_node.cpp
+++ b/src/argon2_node.cpp
@@ -19,10 +19,10 @@ using size_type = std::string::size_type;
 const auto HASH_LEN = 32u;
 
 enum OBJECTS {
-    RESERVED = 0,
-    THIS,
-    RESOLVE,
-    REJECT,
+    kRESERVED = 0,
+    kTHIS,
+    kRESOLVE,
+    kREJECT,
 };
 
 constexpr auto log(uint64_t number, uint64_t base = 2u) -> decltype(number)
@@ -77,8 +77,8 @@ void HashWorker::HandleOKCallback()
     Nan::HandleScope scope;
 
     Local<Value> argv[] = {Nan::Encode(output.get(), strlen(output.get()))};
-    Nan::MakeCallback(GetFromPersistent(THIS).As<Object>(),
-            GetFromPersistent(RESOLVE).As<Function>(), 1, argv);
+    Nan::MakeCallback(GetFromPersistent(kTHIS).As<Object>(),
+            GetFromPersistent(kRESOLVE).As<Function>(), 1, argv);
 }
 
 /* LCOV_EXCL_START */
@@ -89,8 +89,8 @@ void HashWorker::HandleErrorCallback()
     Nan::HandleScope scope;
 
     Local<Value> argv[] = {Nan::New(ErrorMessage()).ToLocalChecked()};
-    Nan::MakeCallback(GetFromPersistent(THIS).As<Object>(),
-            GetFromPersistent(REJECT).As<Function>(), 1, argv);
+    Nan::MakeCallback(GetFromPersistent(kTHIS).As<Object>(),
+            GetFromPersistent(kREJECT).As<Function>(), 1, argv);
 }
 /* LCOV_EXCL_STOP */
 
@@ -117,9 +117,9 @@ NAN_METHOD(Hash) {
                     fromJust<uint32_t>(getArg("parallelism")),
                     fromJust<bool>(getArg("argon2d")) ? Argon2_d : Argon2_i)};
 
-    worker->SaveToPersistent(THIS, info.This());
-    worker->SaveToPersistent(RESOLVE, Local<Function>::Cast(info[3]));
-    worker->SaveToPersistent(REJECT, Local<Function>::Cast(info[4]));
+    worker->SaveToPersistent(kTHIS, info.This());
+    worker->SaveToPersistent(kRESOLVE, Local<Function>::Cast(info[3]));
+    worker->SaveToPersistent(kREJECT, Local<Function>::Cast(info[4]));
 
     Nan::AsyncQueueWorker(worker);
 }
@@ -153,8 +153,8 @@ void VerifyWorker::HandleOKCallback()
     Nan::HandleScope scope;
 
     Local<Value> argv[] = {Nan::New(output)};
-    Nan::MakeCallback(GetFromPersistent(THIS).As<Object>(),
-            GetFromPersistent(RESOLVE).As<Function>(), 1, argv);
+    Nan::MakeCallback(GetFromPersistent(kTHIS).As<Object>(),
+            GetFromPersistent(kRESOLVE).As<Function>(), 1, argv);
 }
 
 /* LCOV_EXCL_START */
@@ -165,8 +165,8 @@ void VerifyWorker::HandleErrorCallback()
     Nan::HandleScope scope;
 
     Local<Value> argv[] = {Nan::New(ErrorMessage()).ToLocalChecked()};
-    Nan::MakeCallback(GetFromPersistent(THIS).As<Object>(),
-            GetFromPersistent(REJECT).As<Function>(), 1, argv);
+    Nan::MakeCallback(GetFromPersistent(kTHIS).As<Object>(),
+            GetFromPersistent(kREJECT).As<Function>(), 1, argv);
 }
 /* LCOV_EXCL_STOP */
 
@@ -182,9 +182,9 @@ NAN_METHOD(Verify) {
     auto worker = new VerifyWorker{{Buffer::Data(hash), Buffer::Length(hash)},
             {Buffer::Data(plain), Buffer::Length(plain)}};
 
-    worker->SaveToPersistent(THIS, info.This());
-    worker->SaveToPersistent(RESOLVE, Local<Function>::Cast(info[2]));
-    worker->SaveToPersistent(REJECT, Local<Function>::Cast(info[3]));
+    worker->SaveToPersistent(kTHIS, info.This());
+    worker->SaveToPersistent(kRESOLVE, Local<Function>::Cast(info[2]));
+    worker->SaveToPersistent(kREJECT, Local<Function>::Cast(info[3]));
 
     Nan::AsyncQueueWorker(worker);
 }


### PR DESCRIPTION
Hey! I had some troubles to get argon2 working on Windows 10 using the Windows SDK 10.0.14393.33, node 6.5.0 and npm 3.10.6. It seems to me that `THIS` is a macro that's defined by `<node.h>`. I thus renamed the constants in the `OBJECTS` enum with a commonly used `k`-prefix. After doing that it works fine again. 😊

Those were the build errors before:
```
..\src\argon2_node.cpp(23): error C2062: type "void" unexpected [C:\projects\node-argon2\build\argon2.vcxproj]
..\src\argon2_node.cpp(23): error C3805: "type": unexpected token, expected either '}' or a ',' [C:\projects\node-argon2\build\argon2.vcxproj]
..\src\argon2_node.cpp(42): warning C4307: "+": integral constant overflow [C:\projects\node-argon2\build\argon2.vcxproj]
..\src\argon2_node.cpp(80): error C2062: type "void" unexpected [C:\projects\node-argon2\build\argon2.vcxproj]
..\src\argon2_node.cpp(92): error C2062: type "void" unexpected [C:\projects\node-argon2\build\argon2.vcxproj]
..\src\argon2_node.cpp(120): error C2062: type "void" unexpected [C:\projects\node-argon2\build\argon2.vcxproj]
..\src\argon2_node.cpp(121): error C2065: "kRESOLVE": undeclared identifier [C:\projects\node-argon2\build\argon2.vcxproj]
..\src\argon2_node.cpp(122): error C2065: "kREJECT": undeclared identifier [C:\projects\node-argon2\build\argon2.vcxproj]
..\src\argon2_node.cpp(156): error C2062: type "void" unexpected [C:\projects\node-argon2\build\argon2.vcxproj]
..\src\argon2_node.cpp(168): error C2062: type "void" unexpected [C:\projects\node-argon2\build\argon2.vcxproj]
..\src\argon2_node.cpp(185): error C2062: type "void" unexpected [C:\projects\node-argon2\build\argon2.vcxproj]
..\src\argon2_node.cpp(186): error C2065: "kRESOLVE": undeclared identifier [C:\projects\node-argon2\build\argon2.vcxproj]
..\src\argon2_node.cpp(187): error C2065: "kREJECT": undeclared identifier [C:\projects\node-argon2\build\argon2.vcxproj]
..\src\argon2_node.cpp(204): warning C4244: 'argument' : conversion from "uint64_t" to "uint32_t", possible loss of data [C:\projects\node-argon2\build\argon2.vcxproj]
```

And these are the errors now:
```
..\src\argon2_node.cpp(42): warning C4307: "+": integral constant overflow [C:\projects\node-argon2\build\argon2.vcxproj]
..\src\argon2_node.cpp(204): warning C4244: 'argument' : conversion from "uint64_t" to "uint32_t", possible loss of data [C:\projects\node-argon2\build\argon2.vcxproj]
```