### PR TITLE
removes use of strdup in hash ok callback

### DIFF
--- a/src/argon2_node.cpp
+++ b/src/argon2_node.cpp
@@ -116,7 +116,7 @@ void HashWorker::HandleOKCallback()
     Nan::HandleScope scope;
 
     v8::Local<v8::Value> argv[] = {
-        Nan::NewBuffer(strdup(output.data()), output.size()).ToLocalChecked()
+        Nan::CopyBuffer(output.data(), output.size()).ToLocalChecked()
     };
     Nan::MakeCallback(GetFromPersistent(THIS_OBJ).As<v8::Object>(),
         GetFromPersistent(RESOLVE).As<v8::Function>(), 1, argv);


### PR DESCRIPTION
Treating the result as a null-terminated string was truncating bytes that were
returned to the caller. Changing this to copy of the raw data fixes the
verification issues when using the resulting hash.

Fixes https://github.com/ranisalt/node-argon2/issues/107