### PR TITLE
Add Hash class to handle results

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,6 @@ const defaults = Object.freeze({
 
 const type2string = []
 
-const rightPad = encoded => encoded + '='.repeat(encoded.length % 4)
-const rightTrim = encoded => encoded.replace(/=+$/, '')
-
 class Hash {
   constructor (hash, options) {
     Object.assign(this, {hash}, options)

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ class Hash {
     return new Hash(hash, {
       type: module.exports[type],
       version: +version,
-      hashLength: Math.floor(hash.length / 4 * 3),
+      hashLength: Math.floor(hash.length),
       memoryCost: Math.log2(+memoryCost),
       timeCost: +timeCost,
       parallelism: +parallelism,

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const crypto = require('crypto')
 const bindings = require('bindings')('argon2')
 const Promise = require('any-promise')
+const phc = require('@phc/format')
 
 const limits = Object.freeze(bindings.limits)
 const types = Object.freeze(bindings.types)
@@ -28,11 +29,16 @@ class Hash {
 
   get digest () {
     const {type, version, memoryCost, timeCost, parallelism, salt, hash} = this
-    console.log(type, version, memoryCost, timeCost, parallelism, salt, hash)
-    return `$${type2string[type]}$v=${version}`
-      + `$m=${1 << memoryCost},t=${timeCost},p=${parallelism}`
-      + `$${rightTrim(salt.toString('base64'))}`
-      + `$${rightTrim(hash.toString('base64'))}`
+    return phc.serialize({
+      id: type2string[type],
+      raw: `v=${version}`,
+      params: {
+        m: (1 << memoryCost).toString(),
+        t: timeCost.toString(),
+        p: parallelism.toString(),
+      },
+      salt, hash
+    })
   }
 
   verify(plain) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/ranisalt/node-argon2#readme",
   "dependencies": {
+    "@phc/format": "^0.1.0",
     "any-promise": "^1.3.0",
     "bindings": "^1.2.1",
     "nan": "^2.4.0"

--- a/src/argon2_node.cpp
+++ b/src/argon2_node.cpp
@@ -47,6 +47,7 @@ Options extractOptions(const v8::Local<v8::Object>& options) {
     ret.time_cost = to_just<uint32_t>(from_object(options, "timeCost"));
     ret.memory_cost = to_just<uint32_t>(from_object(options, "memoryCost"));
     ret.parallelism = to_just<uint32_t>(from_object(options, "parallelism"));
+    ret.version = to_just<uint32_t>(from_object(options, "version"));
     ret.type = argon2_type(to_just<uint32_t>(from_object(options, "type")));
     return ret;
 }

--- a/src/argon2_node.h
+++ b/src/argon2_node.h
@@ -17,6 +17,7 @@ struct Options {
     uint32_t time_cost = {};
     uint32_t memory_cost = {};
     uint32_t parallelism = {};
+    uint32_t version = {};
 
     argon2_type type = {};
 };

--- a/test.js
+++ b/test.js
@@ -195,3 +195,9 @@ test('verify argon2id wrong password', () => {
     })
   })
 })
+
+test('verify from digest', () => {
+  const hash = argon2.verify(hashes.argon2i, 'password').then(matches => {
+    expect(matches).toBeTruthy()
+  })
+})

--- a/test.js
+++ b/test.js
@@ -10,12 +10,15 @@ const salt = Buffer.alloc(16, 'salt')
 // hashes for argon2i and argon2d with default options
 const hashes = Object.freeze({
   argon2i: '$argon2i$v=19$m=4096,t=3,p=1$c2FsdHNhbHRzYWx0c2FsdA$Iv3dSMJ431p24TEj68Kxokm/ilAC9HfwREDIVPM/1/0',
-  withNull: '$argon2i$v=19$m=4096,t=3,p=1$c2FsdHNhbHRzYWx0c2FsdA$Z3fEValT7xBg6b585WOlY2gufWl95ZfkFA8mPtWJ3UM',
-  argon2d: '$argon2d$v=19$m=4096,t=3,p=1$c2FsdHNhbHRzYWx0c2FsdA$3CYaDoobFaprD02HTMVVRLsrSgJjZK5QmqYWnWDEAlw',
-  argon2id: '$argon2id$v=19$m=4096,t=3,p=1$c2FsdHNhbHRzYWx0c2FsdA$fxbFVdPGPQ1NJoy87CaTabyrXOKZepZ9SGBFwPkPJ28',
   rawArgon2i: Buffer.from('22fddd48c278df5a76e13123ebc2b1a249bf8a5002f477f04440c854f33fd7fd', 'hex'),
+
+  withNull: '$argon2i$v=19$m=4096,t=3,p=1$c2FsdHNhbHRzYWx0c2FsdA$Z3fEValT7xBg6b585WOlY2gufWl95ZfkFA8mPtWJ3UM',
   rawWithNull: Buffer.from('6777c455a953ef1060e9be7ce563a563682e7d697de597e4140f263ed589dd43', 'hex'),
+
+  argon2d: '$argon2d$v=19$m=4096,t=3,p=1$c2FsdHNhbHRzYWx0c2FsdA$3CYaDoobFaprD02HTMVVRLsrSgJjZK5QmqYWnWDEAlw',
   rawArgon2d: Buffer.from('dc261a0e8a1b15aa6b0f4d874cc55544bb2b4a026364ae509aa6169d60c4025c', 'hex'),
+
+  argon2id: '$argon2id$v=19$m=4096,t=3,p=1$c2FsdHNhbHRzYWx0c2FsdA$fxbFVdPGPQ1NJoy87CaTabyrXOKZepZ9SGBFwPkPJ28',
   rawArgon2id: Buffer.from('7f16c555d3c63d0d4d268cbcec269369bcab5ce2997a967d486045c0f90f276f', 'hex')
 })
 
@@ -26,61 +29,41 @@ test('defaults', () => {
     memoryCost: 12,
     parallelism: 1,
     type: argon2.argon2i,
-    raw: false
+    version: 0x13
   })
 })
 
 test('basic hash', () => {
   return argon2.hash(password, {salt}).then(hash => {
-    expect(hash).toBe(hashes.argon2i)
+    expect(hash.digest).toBe(hashes.argon2i)
+    expect(hash.hash).toEqual(hashes.rawArgon2i)
   })
 })
 
 test('hash with null in password', () => {
   return argon2.hash('pass\0word', {salt}).then(hash => {
-    expect(hash).toBe(hashes.withNull)
-  })
-})
-
-test('with raw hash', () => {
-  return argon2.hash(password, {raw: true, salt}).then(hash => {
-    expect(hash).toEqual(hashes.rawArgon2i)
-  })
-})
-
-test('with raw hash, null in password', () => {
-  return argon2.hash('pass\0word', {raw: true, salt}).then(hash => {
-    expect(hash).toEqual(hashes.rawWithNull)
+    expect(hash.digest).toBe(hashes.withNull)
+    expect(hash.hash).toEqual(hashes.rawWithNull)
   })
 })
 
 test('hash with argon2d', () => {
   return argon2.hash(password, {type: argon2.argon2d, salt}).then(hash => {
-    expect(hash).toBe(hashes.argon2d)
-  })
-})
-
-test('argon2d with raw hash', () => {
-  return argon2.hash(password, {type: argon2.argon2d, raw: true, salt}).then(hash => {
-    expect(hash).toEqual(hashes.rawArgon2d)
+    expect(hash.digest).toBe(hashes.argon2d)
+    expect(hash.hash).toEqual(hashes.rawArgon2d)
   })
 })
 
 test('hash with argon2id', () => {
   return argon2.hash(password, {type: argon2.argon2id, salt}).then(hash => {
-    expect(hash).toBe(hashes.argon2id)
-  })
-})
-
-test('argon2id with raw hash', () => {
-  return argon2.hash(password, {type: argon2.argon2id, raw: true, salt}).then(hash => {
-    expect(hash).toEqual(hashes.rawArgon2id)
+    expect(hash.digest).toBe(hashes.argon2id)
+    expect(hash.hash).toEqual(hashes.rawArgon2id)
   })
 })
 
 test('hash with time cost', () => {
   return argon2.hash(password, {timeCost: 4}).then(hash => {
-    expect(hash).toMatch(/t=4/)
+    expect(hash.digest).toMatch(/t=4/)
   })
 })
 
@@ -117,7 +100,7 @@ test('hash with high hash length', () => {
 
 test('hash with memory cost', () => {
   return argon2.hash(password, {memoryCost: 13}).then(hash => {
-    expect(hash).toMatch(/m=8192/)
+    expect(hash.digest).toMatch(/m=8192/)
   })
 })
 
@@ -135,7 +118,7 @@ test('hash with high memory cost', () => {
 
 test('hash with parallelism', () => {
   return argon2.hash(password, {parallelism: 2}).then(hash => {
-    expect(hash).toMatch(/p=2/)
+    expect(hash.digest).toMatch(/p=2/)
   })
 })
 
@@ -153,13 +136,13 @@ test('hash with high parallelism', () => {
 
 test('hash with all options', () => {
   return argon2.hash(password, {timeCost: 4, memoryCost: 13, parallelism: 2}).then(hash => {
-    expect(hash).toMatch(/m=8192,t=4,p=2/)
+    expect(hash.digest).toMatch(/m=8192,t=4,p=2/)
   })
 })
 
 test('verify correct password', () => {
   return argon2.hash(password).then(hash => {
-    return argon2.verify(hash, password).then(matches => {
+    return hash.verify(password).then(matches => {
       expect(matches).toBeTruthy()
     })
   })
@@ -167,7 +150,7 @@ test('verify correct password', () => {
 
 test('verify wrong password', () => {
   return argon2.hash(password).then(hash => {
-    return argon2.verify(hash, 'passworld').then(matches => {
+    return hash.verify('passworld').then(matches => {
       expect(matches).toBeFalsy()
     })
   })
@@ -175,7 +158,7 @@ test('verify wrong password', () => {
 
 test('verify with null in password', () => {
   return argon2.hash('pass\0word').then(hash => {
-    return argon2.verify(hash, 'pass\0word').then(matches => {
+    return hash.verify('pass\0word').then(matches => {
       expect(matches).toBeTruthy()
     })
   })
@@ -183,7 +166,7 @@ test('verify with null in password', () => {
 
 test('verify argon2d correct password', () => {
   return argon2.hash(password, {type: argon2.argon2d}).then(hash => {
-    return argon2.verify(hash, password).then(matches => {
+    return hash.verify(password).then(matches => {
       expect(matches).toBeTruthy()
     })
   })
@@ -191,7 +174,7 @@ test('verify argon2d correct password', () => {
 
 test('verify argon2d wrong password', () => {
   return argon2.hash(password, {type: argon2.argon2d}).then(hash => {
-    return argon2.verify(hash, 'passworld').then(matches => {
+    return hash.verify('passworld').then(matches => {
       expect(matches).toBeFalsy()
     })
   })
@@ -199,7 +182,7 @@ test('verify argon2d wrong password', () => {
 
 test('verify argon2id correct password', () => {
   return argon2.hash(password, {type: argon2.argon2id}).then(hash => {
-    return argon2.verify(hash, password).then(matches => {
+    return hash.verify(password).then(matches => {
       expect(matches).toBeTruthy()
     })
   })
@@ -207,7 +190,7 @@ test('verify argon2id correct password', () => {
 
 test('verify argon2id wrong password', () => {
   return argon2.hash(password, {type: argon2.argon2id}).then(hash => {
-    return argon2.verify(hash, 'passworld').then(matches => {
+    return hash.verify('passworld').then(matches => {
       expect(matches).toBeFalsy()
     })
   })

--- a/test.js
+++ b/test.js
@@ -197,7 +197,7 @@ test('verify argon2id wrong password', () => {
 })
 
 test('verify from digest', () => {
-  const hash = argon2.verify(hashes.argon2i, 'password').then(matches => {
+  return argon2.verify(hashes.argon2i, password).then(matches => {
     expect(matches).toBeTruthy()
   })
 })


### PR DESCRIPTION
The hash class stores Argon2 parameters in an object and has a `digest` property that generates the encoded hash in PHC format. You can access the raw hash, salt and any other parameter this way.

There are issues to iron out yet:
- Maybe implement `.toString()` on Hash?
- `argon2.verify` only handle digests, not Hash, maybe export Hash?