### PR TITLE
Handle secret (keyed hashing) and associated data

### DIFF
--- a/argon2.js
+++ b/argon2.js
@@ -18,7 +18,7 @@ const defaults = Object.freeze({
   version
 })
 
-const type2string = []
+const secrets = new Map()
 
 const hash = (plain, options) => {
   options = Object.assign({}, defaults, options)
@@ -40,6 +40,10 @@ const hash = (plain, options) => {
         `Replacing memoryCost ${exp} with 2**${exp}=${1 << exp}.\n`
       })
       options.memoryCost = 1 << exp
+    }
+
+    if ('keyid' in options) {
+      options.secret = secrets.get(options.keyid)
     }
 
     if ('salt' in options) {
@@ -68,6 +72,9 @@ const hash = (plain, options) => {
       return output.hash
     }
 
+    if ('keyid' in options) {
+      output.params.keyid = options.keyid
+    }
     return phc.serialize(output)
   })
 }
@@ -87,7 +94,7 @@ const verify = (digest, plain) => {
   const {
     id: type, version = 0x10, params: {
       m: memoryCost, t: timeCost, p: parallelism
-    }, salt, hash
+    }, keyid, salt, hash
   } = phc.deserialize(digest)
   return new Promise((resolve, reject) => {
     const options = {
@@ -97,6 +104,7 @@ const verify = (digest, plain) => {
       memoryCost: +memoryCost,
       timeCost: +timeCost,
       parallelism: +parallelism,
+      keyid,
       salt
     }
     bindings.hash(Buffer.from(plain), options, (err, value) => {
@@ -114,10 +122,10 @@ module.exports = {
   limits,
   hash,
   needsRehash,
+  secrets,
   verify
 }
 
 for (const k of Object.keys(types)) {
   module.exports[k] = types[k]
-  type2string[types[k]] = k
 }

--- a/src/argon2_node.cpp
+++ b/src/argon2_node.cpp
@@ -33,6 +33,7 @@ public:
 
     std::string salt;
     std::string secret;
+    std::string data;
 
     uint32_t hash_length = {};
     uint32_t time_cost = {};
@@ -55,8 +56,8 @@ argon2_context make_context(char* buf, const std::string& plain,
     ctx.saltlen = options.salt.size();
     ctx.secret = reinterpret_cast<uint8_t*>(const_cast<char*>(options.secret.data()));
     ctx.secretlen = options.secret.size();
-    ctx.ad = nullptr;
-    ctx.adlen = 0;
+    ctx.ad = reinterpret_cast<uint8_t*>(const_cast<char*>(options.data.data()));
+    ctx.adlen = options.data.size();
     ctx.t_cost = options.time_cost;
     ctx.m_cost = options.memory_cost;
     ctx.lanes = options.parallelism;
@@ -158,6 +159,7 @@ Options extract_options(const v8::Local<v8::Object>& options)
     Options ret;
     ret.salt = require_string(options, "salt");
     ret.secret = optional_string(options, "secret");
+    ret.data = optional_string(options, "data");
     ret.hash_length = require_uint32(options, "hashLength");
     ret.time_cost = require_uint32(options, "timeCost");
     ret.memory_cost = require_uint32(options, "memoryCost");

--- a/src/argon2_node.cpp
+++ b/src/argon2_node.cpp
@@ -53,8 +53,8 @@ argon2_context make_context(char* buf, const std::string& plain,
     ctx.pwdlen = plain.size();
     ctx.salt = reinterpret_cast<uint8_t*>(const_cast<char*>(options.salt.data()));
     ctx.saltlen = options.salt.size();
-    ctx.secret = nullptr;
-    ctx.secretlen = 0;
+    ctx.secret = reinterpret_cast<uint8_t*>(const_cast<char*>(options.secret.data()));
+    ctx.secretlen = options.secret.size();
     ctx.ad = nullptr;
     ctx.adlen = 0;
     ctx.t_cost = options.time_cost;

--- a/test/test.js
+++ b/test/test.js
@@ -14,6 +14,9 @@ const hashes = Object.freeze({
   rawWithNull: Buffer.from('6777c455a953ef1060e9be7ce563a563682e7d697de597e4140f263ed589dd43', 'hex'),
   rawArgon2d: Buffer.from('dc261a0e8a1b15aa6b0f4d874cc55544bb2b4a026364ae509aa6169d60c4025c', 'hex'),
   rawArgon2id: Buffer.from('7f16c555d3c63d0d4d268cbcec269369bcab5ce2997a967d486045c0f90f276f', 'hex'),
+  vectorArgon2i: Buffer.from('b8521368599f4b5f9595ab4a678464a46bb59d428c821bf164c96056c6a31a', 'hex'),
+  vectorArgon2d: Buffer.from('0a1a76a9e891fca7891a50712878283f5c5dc1c98436e6b516bcbb18a334ae3e', 'hex'),
+  vectorArgon2id: Buffer.from('afd2cece865d3cb0ac6a3ac9b5af84f15c7ffec721aca1ea97bfea30c5337b', 'hex'),
   oldFormat: '$argon2i$m=4096,t=3,p=1$tbagT6b1YH33niCo9lVzuA$htv/k+OqWk1V9zD9k5DOBi2kcfcZ6Xu3tWmwEPV3/nc'
 })
 
@@ -247,6 +250,40 @@ describe('Argon2', () => {
       return argon2.verify(hashes.oldFormat, 'password').then(matches => {
         assert(matches)
       })
+    })
+  })
+
+  describe('test vectors', () => {
+    const password = Buffer.alloc(32, 0x01)
+
+    const options = {
+      raw: true,
+      memoryCost: 32768,
+      timeCost: 3,
+      parallelism: 4,
+      hashLength: 32,
+      salt: Buffer.alloc(16, 0x02),
+      keyid: 'test-vector',
+      data: Buffer.alloc(12, 0x04)
+    }
+
+    argon2.secrets.set(options.keyid, Buffer.alloc(8, 0x03))
+
+    // TODO: decipher what the test vectors actually mean and compare against
+
+    it('validate argon2d', () => {
+      return argon2.hash(password, Object.assign({type: argon2d}, options))
+        .then(hash => hash.equals(hashes.vectorArgon2d))
+    })
+
+    it('validate argon2i', () => {
+      return argon2.hash(password, Object.assign({type: argon2i}, options))
+        .then(hash => hash.equals(hashes.vectorArgon2i))
+    })
+
+    it('validate argon2id', () => {
+      return argon2.hash(password, Object.assign({type: argon2id}, options))
+        .then(hash => hash.equals(hashes.vectorArgon2id))
     })
   })
 })


### PR DESCRIPTION
Adds two more parameters for hashes: `ad` and `keyid`. Text from Argon2 specs:

- "The `secret` parameter, which is used for [keyed hashing](https://en.wikipedia.org/wiki/Hash-based_message_authentication_code). This allows a secret key to be input at hashing time (from some external location) and be folded into the value of the hash. This means that even if your salts and hashes are compromized, an attacker cannot brute-force to find the password without the key."

- "The `ad` parameter, which is used to fold any additional data into the hash value. Functionally, this behaves almost exactly like the `secret` or `salt` parameters; the `ad` parameter is folding into the value of the hash. However, this parameter is used for different data. The `salt` should be a random string stored alongside your password. The `secret` should be a random key only usable at hashing time. The `ad` is for any other data."

To use the `secret`, you should first supply your set of keys to the module. It exports a `secrets` map and you can push keys/secrets to it with `argon2.secrets.set('<keyid>', <secret>)` where `<secret>`  is a buffer.

This closes #58 and requires further discussion on the API.