### PR TITLE
Added saltLength to Options in declaration file

### DIFF
--- a/argon2.d.ts
+++ b/argon2.d.ts
@@ -10,6 +10,7 @@ export interface Options {
     type?: 0 | 1 | 2;
     version?: number;
     salt?: Buffer;
+    saltLength?: number;
     raw?: boolean;
 }
 


### PR DESCRIPTION
The options interface is missing the added saltLength option from https://github.com/ranisalt/node-argon2/commit/a74d392b82f09527d24a264a86a34c03b889e569