### PR TITLE
Hasher class

### DIFF
--- a/argon2.js
+++ b/argon2.js
@@ -1,123 +1,114 @@
 'use strict'
 const crypto = require('crypto')
-const bindings = require('bindings')('argon2')
+const { hash, limits, types, version } = require('bindings')('argon2')
 const Promise = require('any-promise')
 const phc = require('@phc/format')
 
-const limits = Object.freeze(bindings.limits)
-const types = Object.freeze(bindings.types)
-const version = bindings.version
+let defaultHasher
+class Hasher {
+  // TODO: this is just for backwards compat, please create new Hasher instance
+  static get hash () { return defaultHasher.hash.bind(defaultHasher) }
+  static get needsRehash () { return defaultHasher.needsRehash.bind(defaultHasher) }
+  static get verify () { return defaultHasher.verify.bind(defaultHasher) }
 
-const defaults = Object.freeze({
-  hashLength: 32,
-  saltLength: 16,
-  timeCost: 3,
-  memoryCost: 1 << 12,
-  parallelism: 1,
-  type: types.argon2i,
-  version
-})
-
-const type2string = []
-
-const hash = (plain, options) => {
-  options = Object.assign({}, defaults, options)
-
-  return new Promise((resolve, reject) => {
-    for (const key of Object.keys(limits)) {
-      const {max, min} = limits[key]
-      const value = options[key]
-      if (value > max || value < min) {
-        reject(new Error(`Invalid ${key}, must be between ${min} and ${max}.`))
-      }
+  static get argon2i () { return types.argon2i }
+  static get argon2d () { return types.argon2d }
+  static get argon2id () { return types.argon2id }
+  static get defaults () {
+    return {
+      hashLength: 32,
+      saltLength: 16,
+      timeCost: 3,
+      memoryCost: 1 << 12,
+      parallelism: 1,
+      type: Hasher.argon2i,
+      version
     }
+  }
+  static get limits () { return limits }
 
-    // TODO: after transition time, drop this check
-    if (options.memoryCost < 32) {
-      const exp = options.memoryCost
-      process.emitWarning('[argon2] deprecated usage of options.memoryCost', {
-        detail: 'The argon2 package now uses value of memory cost instead of exponent.\n' +
-        `Replacing memoryCost ${exp} with 2**${exp}=${1 << exp}.\n`
-      })
-      options.memoryCost = 1 << exp
-    }
+  constructor (options) {
+    this.options = Object.assign({}, Hasher.defaults, options)
+  }
 
-    if ('salt' in options) {
-      return resolve(options.salt)
-    }
+  hash (plain, options) {
+    options = Object.assign({}, this.options, options)
 
-    crypto.randomBytes(options.saltLength, (err, salt) => {
-      /* istanbul ignore if */
-      if (err) {
-        return reject(err)
-      }
-      return resolve(salt)
-    })
-  }).then(salt => {
     return new Promise((resolve, reject) => {
-      bindings.hash(Buffer.from(plain), Object.assign(options, {salt}), (err, value) => {
+      for (const [key, {max, min}] of Object.entries(Hasher.limits)) {
+        const value = options[key]
+        if (value > max || value < min) {
+          return reject(new Error(`Invalid ${key}, must be between ${min} and ${max}.`))
+        }
+      }
+
+      if ('salt' in options) {
+        return resolve(options.salt)
+      }
+
+      crypto.randomBytes(options.saltLength, (err, salt) => {
         /* istanbul ignore if */
         if (err) {
           return reject(err)
         }
-        return resolve(value)
+        return resolve(salt)
       })
-    })
-  }).then(output => {
-    if (options.raw) {
-      return output.hash
-    }
-
-    return phc.serialize(output)
-  })
-}
-
-const needsRehash = (digest, options) => {
-  options = Object.assign({}, defaults, options)
-
-  const {
-    version, params: {m: memoryCost, t: timeCost}
-  } = phc.deserialize(digest)
-  return +version !== +options.version ||
-    +memoryCost !== +options.memoryCost ||
-    +timeCost !== +options.timeCost
-}
-
-const verify = (digest, plain) => {
-  const {
-    id: type, version = 0x10, params: {
-      m: memoryCost, t: timeCost, p: parallelism
-    }, salt, hash
-  } = phc.deserialize(digest)
-  return new Promise((resolve, reject) => {
-    const options = {
-      type: module.exports[type],
-      version: +version,
-      hashLength: hash.length,
-      memoryCost: +memoryCost,
-      timeCost: +timeCost,
-      parallelism: +parallelism,
-      salt
-    }
-    bindings.hash(Buffer.from(plain), options, (err, value) => {
-      /* istanbul ignore if */
-      if (err) {
-        return reject(err)
+    }).then(salt => {
+      return new Promise((resolve, reject) => {
+        hash(Buffer.from(plain), Object.assign(options, {salt}), (err, value) => {
+          /* istanbul ignore if */
+          if (err) {
+            return reject(err)
+          }
+          return resolve(value)
+        })
+      })
+    }).then(output => {
+      if (options.raw) {
+        return output.hash
       }
-      return resolve(value.hash)
+
+      return phc.serialize(output)
     })
-  }).then(expected => expected.equals(hash))
+  }
+
+  needsRehash (digest, options) {
+    options = Object.assign({}, Hasher.defaults, options)
+
+    const {
+      version, params: {m: memoryCost, t: timeCost}
+    } = phc.deserialize(digest)
+    return +version !== +options.version ||
+      +memoryCost !== +options.memoryCost ||
+      +timeCost !== +options.timeCost
+  }
+
+  verify (digest, plain) {
+    const {
+      id: type, version = 0x10, params: {
+        m: memoryCost, t: timeCost, p: parallelism
+      }, salt, hash: input
+    } = phc.deserialize(digest)
+    return new Promise((resolve, reject) => {
+      const options = {
+        type: Hasher[type],
+        version: +version,
+        hashLength: input.length,
+        memoryCost: +memoryCost,
+        timeCost: +timeCost,
+        parallelism: +parallelism,
+        salt
+      }
+      hash(Buffer.from(plain), options, (err, value) => {
+        /* istanbul ignore if */
+        if (err) {
+          return reject(err)
+        }
+        return resolve(value.hash)
+      })
+    }).then(expected => expected.equals(input))
+  }
 }
 
-module.exports = {
-  defaults,
-  limits,
-  hash,
-  needsRehash,
-  verify
-}
-
-for (const k of Object.keys(types)) {
-  module.exports[k] = types[k]
-  type2string[types[k]] = k
-}
+defaultHasher = new Hasher()
+module.exports = Hasher


### PR DESCRIPTION
As a lot of other hashing utilities, and as I previously proposed, having a Hasher instance instead of global functions would allow better handling of options. This PR maintains easily droppable backwards compatibility, considering we still didn't reach 1.0 maturity.