### PR TITLE
Convert to use N-API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
+dist: xenial
 language: node_js
 node_js:
   - "6"
   - "8"
   - "10"
+  - "11"
 addons:
   apt:
     packages:

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,6 +1,7 @@
 {
   "target_defaults": {
-    "include_dirs": ["argon2/include"],
+    "include_dirs": [
+      "<!@(node -p \"require('node-addon-api').include\")","argon2/include"],
     "target_conditions": [
       ["OS == 'mac'", {
         "xcode_settings": {
@@ -23,6 +24,15 @@
   "targets": [
     {
       "target_name": "libargon2",
+      "cflags!": [ "-fno-exceptions" ],
+      "cflags_cc!": [ "-fno-exceptions" ],
+      "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+        "CLANG_CXX_LIBRARY": "libc++",
+        "MACOSX_DEPLOYMENT_TARGET": "10.7",
+      },
+      "msvs_settings": {
+        "VCCLCompilerTool": { "ExceptionHandling": 1 },
+      },
       "sources": [
         "argon2/src/argon2.c",
         "argon2/src/core.c",
@@ -42,12 +52,22 @@
       "type": "static_library"
     }, {
       "target_name": "argon2",
+      "cflags!": [ "-fno-exceptions" ],
+      "cflags_cc!": [ "-fno-exceptions" ],
+      "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+        "CLANG_CXX_LIBRARY": "libc++",
+        "MACOSX_DEPLOYMENT_TARGET": "10.7",
+      },
+      "msvs_settings": {
+        "VCCLCompilerTool": { "ExceptionHandling": 1 },
+      },
       "sources": [
         "src/argon2_node.cpp"
       ],
       "cflags+": ["-Wno-cast-function-type"],
-      "include_dirs+": ["<!(node -e \"require('nan')\")"],
-      "dependencies": ["libargon2"],
+      "include_dirs+": ["<!@(node -p \"require('node-addon-api').include\")"],
+      "dependencies": [
+        "<!(node -p 'require(\"node-addon-api\").gyp')","libargon2"],
       "configurations": {
         "Debug": {
           "conditions": [

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,11 +1,11 @@
 {
   "target_defaults": {
-    "include_dirs": [
-      "<!@(node -p \"require('node-addon-api').include\")","argon2/include"],
+    "include_dirs": ["argon2/include"],
     "target_conditions": [
       ["OS == 'mac'", {
         "xcode_settings": {
-          "MACOSX_DEPLOYMENT_TARGET": "10.9",
+          "CLANG_CXX_LIBRARY": "libc++",
+          "MACOSX_DEPLOYMENT_TARGET": "10.7",
         }
       }]
     ],
@@ -24,15 +24,6 @@
   "targets": [
     {
       "target_name": "libargon2",
-      "cflags!": [ "-fno-exceptions" ],
-      "cflags_cc!": [ "-fno-exceptions" ],
-      "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
-        "CLANG_CXX_LIBRARY": "libc++",
-        "MACOSX_DEPLOYMENT_TARGET": "10.7",
-      },
-      "msvs_settings": {
-        "VCCLCompilerTool": { "ExceptionHandling": 1 },
-      },
       "sources": [
         "argon2/src/argon2.c",
         "argon2/src/core.c",
@@ -52,11 +43,8 @@
       "type": "static_library"
     }, {
       "target_name": "argon2",
-      "cflags!": [ "-fno-exceptions" ],
-      "cflags_cc!": [ "-fno-exceptions" ],
-      "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
-        "CLANG_CXX_LIBRARY": "libc++",
-        "MACOSX_DEPLOYMENT_TARGET": "10.7",
+      "xcode_settings": {
+        "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
       },
       "msvs_settings": {
         "VCCLCompilerTool": { "ExceptionHandling": 1 },
@@ -64,10 +52,9 @@
       "sources": [
         "src/argon2_node.cpp"
       ],
-      "cflags+": ["-Wno-cast-function-type"],
-      "include_dirs+": ["<!@(node -p \"require('node-addon-api').include\")"],
-      "dependencies": [
-        "<!(node -p 'require(\"node-addon-api\").gyp')","libargon2"],
+      "cflags_cc!": ["-fno-exceptions"],
+      "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+      "dependencies": ["<!(node -p 'require(\"node-addon-api\").gyp')", "libargon2"],
       "configurations": {
         "Debug": {
           "conditions": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -186,10 +186,10 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+    "node-addon-api": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.6.0.tgz",
+      "integrity": "sha512-HEUPBHfdH4CLR1Qq4/Ek8GT/qFSvpApjJQmcYdLCL51ADU/Y11kMuFAdIevhNrPh3ylqVGA8k6vI/oi4YUAHbA=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   },
   "homepage": "https://github.com/ranisalt/node-argon2#readme",
   "dependencies": {
+    "node-addon-api": "^1.6.0",
     "@phc/format": "^0.5.0",
     "any-promise": "^1.3.0",
-    "bindings": "^1.3.0",
-    "nan": "^2.10.0"
+    "bindings": "^1.3.0"
   },
   "devDependencies": {
     "@types/node": "^10.12.10",

--- a/src/argon2_node.cpp
+++ b/src/argon2_node.cpp
@@ -7,43 +7,42 @@
 #include <napi.h>
 #include "../argon2/include/argon2.h"
 
+using namespace Napi;
+
 #ifndef _MSC_VER
 namespace {
 #endif
 
-class Options {
-public:
+struct Options {
     // TODO: remove ctors and initializers when GCC<5 stops shipping on Ubuntu
-    Options() = default;
     Options(Options&&) = default;
 
-    Napi::Object dump(const std::string& hash,
-                      const Napi::Env&   env) const
+    Object dump(const std::string& hash, const Env& env) const
     {
-        Napi::Object out = Napi::Object::New(env);
-        out.Set(Napi::String::New(env, "id"), Napi::String::New(env, argon2_type2string(type, false)));
-        out.Set(Napi::String::New(env, "version"), Napi::Number::New(env, version));
+        auto out = Object::New(env);
+        out.Set(String::New(env, "id"), String::New(env, argon2_type2string(type, false)));
+        out.Set(String::New(env, "version"), Number::New(env, version));
 
-        auto params = Napi::Object::New(env);
-        params.Set(Napi::String::New(env, "m"), Napi::Number::New(env, memory_cost));
-        params.Set(Napi::String::New(env, "t"), Napi::Number::New(env, time_cost));
-        params.Set(Napi::String::New(env, "p"), Napi::Number::New(env, parallelism));
-        out.Set(Napi::String::New(env, "params"), params);
+        auto params = Object::New(env);
+        params.Set(String::New(env, "m"), Number::New(env, memory_cost));
+        params.Set(String::New(env, "t"), Number::New(env, time_cost));
+        params.Set(String::New(env, "p"), Number::New(env, parallelism));
+        out.Set(String::New(env, "params"), params);
 
-        out.Set(Napi::String::New(env, "salt"), Napi::Buffer<char>::Copy(env, salt.c_str(), salt.size()));
-        out.Set(Napi::String::New(env, "hash"), Napi::Buffer<char>::Copy(env, hash.c_str(), hash.size()));
+        out.Set(String::New(env, "salt"), Buffer<char>::Copy(env, salt.c_str(), salt.size()));
+        out.Set(String::New(env, "hash"), Buffer<char>::Copy(env, hash.c_str(), hash.size()));
         return out;
     }
 
     std::string salt;
 
-    uint32_t hash_length = {};
-    uint32_t time_cost = {};
-    uint32_t memory_cost = {};
-    uint32_t parallelism = {};
-    uint32_t version = {};
+    uint32_t hash_length;
+    uint32_t time_cost;
+    uint32_t memory_cost;
+    uint32_t parallelism;
+    uint32_t version;
 
-    argon2_type type = {};
+    argon2_type type;
 };
 
 argon2_context make_context(char* buf, const std::string& plain,
@@ -72,16 +71,12 @@ argon2_context make_context(char* buf, const std::string& plain,
     return ctx;
 }
 
-class HashWorker final: public Napi::AsyncWorker {
+class HashWorker final: public AsyncWorker {
 public:
-    HashWorker(const Napi::Function& callback,
-               std::string plain,
-               Options options,
-               Napi::Env env) :
-        Napi::AsyncWorker{callback, "argon2:HashWorker"},
+    HashWorker(const Function& callback, std::string plain, Options options):
+        AsyncWorker{callback, "argon2:HashWorker"},
         plain{std::move(plain)},
-        options{std::move(options)},
-        env{std::move(env)}
+        options{std::move(options)}
     {}
 
     void Execute() override
@@ -112,8 +107,9 @@ public:
 
     void OnOK() override
     {
-        Napi::HandleScope scope(env);
-        Callback().Call({env.Null(), options.dump(hash, env)});
+        const auto& env = Env();
+        HandleScope scope{env};
+        Callback().Call({env.Undefined(), options.dump(hash, env)});
     }
 
 private:
@@ -121,67 +117,59 @@ private:
     Options options;
 
     std::string hash;
-    Napi::Env env;
 };
 
-using size_type = std::string::size_type;
-
-Napi::Value from_object(const Napi::Object& object, const char* key)
+Value from_object(const Object& object, const char* key)
 {
-    return object.Get(Napi::Value::From(object.Env(), key));
+    return object.Get(Value::From(object.Env(), key));
 }
 
-std::string buffer_to_string(const Napi::Value& value)
+std::string buffer_to_string(const Value& value)
 {
-    auto buffer = value.As<Napi::Buffer<char> >();
+    const auto& buffer = value.As<Buffer<char>>();
     return {buffer.Data(), buffer.Length()};
 }
 
-Options extract_options(const Napi::Object& options)
+Options extract_options(const Object& options)
 {
-    Options ret;
-    ret.salt = buffer_to_string(from_object(options, "salt"));
-    ret.hash_length = from_object(options, "hashLength").ToNumber();
-    ret.time_cost = from_object(options, "timeCost").ToNumber();
-    ret.memory_cost = from_object(options, "memoryCost").ToNumber();
-    ret.parallelism = from_object(options, "parallelism").ToNumber();
-    ret.version = from_object(options, "version").ToNumber();
-    uint32_t type = from_object(options, "type").ToNumber();
-    ret.type = static_cast<argon2_type>(type);
-
-    return ret;
+    return {
+        buffer_to_string(from_object(options, "salt")),
+        from_object(options, "hashLength").ToNumber(),
+        from_object(options, "timeCost").ToNumber(),
+        from_object(options, "memoryCost").ToNumber(),
+        from_object(options, "parallelism").ToNumber(),
+        from_object(options, "version").ToNumber(),
+        static_cast<argon2_type>(int(from_object(options, "type").ToNumber())),
+    };
 }
 
 #ifndef _MSC_VER
 }
 #endif
 
-Napi::Value Hash(const Napi::CallbackInfo& info) {
-    assert(info.Length() == 3 and
-           info[0].IsBuffer() and
-           info[1].IsObject() and
-           info[2].IsFunction());
+Value Hash(const CallbackInfo& info) {
+    assert(info.Length() == 3 and info[0].IsBuffer() and info[1].IsObject() and info[2].IsFunction());
 
     std::string plain = buffer_to_string(info[0]);
-    auto options = info[1].As<Napi::Object>();
-    auto callback = info[2].As<Napi::Function>();
+    const auto& options = info[1].As<Object>();
+    auto callback = info[2].As<Function>();
 
     auto worker = new HashWorker{
-        callback, std::move(plain), extract_options(options), info.Env()
+        callback, std::move(plain), extract_options(options)
     };
 
     worker->Queue();
     return info.Env().Undefined();
 }
 
-Napi::Object init(Napi::Env env, Napi::Object exports) {
-    auto limits = Napi::Object::New(env);
+Object init(Env env, Object exports) {
+    auto limits = Object::New(env);
 
     const auto setMaxMin = [&](const char* name, uint32_t max, uint32_t min) {
-        auto obj = Napi::Object::New(env);
-        (obj).Set(Napi::String::New(env, "max"), Napi::Number::New(env, max));
-        (obj).Set(Napi::String::New(env, "min"), Napi::Number::New(env, min));
-        (limits).Set(Napi::String::New(env, name), obj);
+        auto obj = Object::New(env);
+        obj.Set(String::New(env, "max"), Number::New(env, max));
+        obj.Set(String::New(env, "min"), Number::New(env, min));
+        limits.Set(String::New(env, name), obj);
     };
 
     setMaxMin("hashLength", ARGON2_MAX_OUTLEN, ARGON2_MIN_OUTLEN);
@@ -189,24 +177,22 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
     setMaxMin("timeCost", ARGON2_MAX_TIME, ARGON2_MIN_TIME);
     setMaxMin("parallelism", ARGON2_MAX_LANES, ARGON2_MIN_LANES);
 
-    auto types = Napi::Object::New(env);
+    auto types = Object::New(env);
 
     const auto setType = [&](argon2_type type) {
-        types.Set(Napi::String::New(env, argon2_type2string(type, false)),
-                  Napi::Number::New(env, type));
+        types.Set(String::New(env, argon2_type2string(type, false)), Number::New(env, type));
     };
 
     setType(Argon2_d);
     setType(Argon2_i);
     setType(Argon2_id);
 
-    auto hashFunc = Napi::Function::New(env, Hash);
+    const auto& hashFunc = Function::New(env, Hash);
 
-    exports.Set(Napi::String::New(env, "limits"), limits);
-    exports.Set(Napi::String::New(env, "types"), types);
-    exports.Set(Napi::String::New(env, "version"),
-            Napi::Number::New(env, ARGON2_VERSION_NUMBER));
-    exports.Set(Napi::String::New(env, "hash"), hashFunc);
+    exports.Set(String::New(env, "limits"), limits);
+    exports.Set(String::New(env, "types"), types);
+    exports.Set(String::New(env, "version"), Number::New(env, ARGON2_VERSION_NUMBER));
+    exports.Set(String::New(env, "hash"), hashFunc);
     return exports;
 }
 


### PR DESCRIPTION
[N-API](https://nodejs.org/api/n-api.html) gives ABI stability and it is VM-agnostic (doesn't bind to V8, or a specific version of V8)

Tested with `npm test`

This conversion was done with the conversion tool provided by `node-addon-api`. Then I manually went over and fixed all compilation errors and tests issues.