### PR TITLE
Added needsRehash function to declaration file

### DIFF
--- a/argon2.d.ts
+++ b/argon2.d.ts
@@ -35,3 +35,4 @@ export const limits: OptionLimits;
 export function hash(plain: Buffer | string, options: Options & {raw: true}): Promise<Buffer>;
 export function hash(plain: Buffer | string, options?: Options & {raw?: false}): Promise<string>;
 export function verify(hash: string, plain: Buffer | string): Promise<boolean>;
+export function needsRehash(hash: string, options?: Options): boolean;


### PR DESCRIPTION
Declaration file is missing entry for the `needsRehash` function, added in eb1d115da02b0869945672a021dea6b9b374f7f7.