### PR TITLE
Add platform info to prebuilt binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "binary": {
     "module_name": "argon2",
-    "module_path": "./lib/binding/",
+    "module_path": "./lib/binding/{platform}-{arch}/",
     "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{arch}-{libc}.tar.gz",
     "host": "https://github.com/ranisalt/node-argon2/releases/download",
     "remote_path": "v{version}"


### PR DESCRIPTION
Addresses https://github.com/ranisalt/node-argon2/issues/209.

Adding `{platform}-{arch}` to the `module_path` property in _package.json_ helps node-pre-gyp make platform-specific builds of argon2. On macOS, running `npm install` on a fresh copy of the repo produces a binary at _lib/binding/darwin-x64/argon2.node_. I assume that whatever CI you have that creates the npm tarball runs on a linux box, so that package will have a binary at _lib/binding/linux-x64/argon2.node_. When macOS users install argon2 into their projects through npm, node-pre-gyp should correctly reject the included linux binary, causing it to fall back to rebuilding from source.

I verified that the call to `npx node-pre-gyp package` in _.travis.yml_ and _appveyor.yml_ automatically uses the new path to the binary.

I don't know if there's anything else I'm missing.