### PR TITLE
Update coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,26 @@ jobs:
 
     - name: Run tests
       run: yarn test
+
+    - name: Generate coverage
+      run: yarn nyc report --reporter=text-lcov > lcov-js.info
+    
+    - name: Send to Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: ./lcov-js.info
+        parallel: true
+
+  end-coveralls:
+    needs: build
+
+    name: End Coveralls report
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: End Coveralls parallel job
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        parallel-finished: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
 
     name: Build node-${{ matrix.node-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      npm_config_debug: yes
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     name: Build node-${{ matrix.node-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
+      YARN_GPG: no
       npm_config_debug: yes
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
 
     name: Build node-${{ matrix.node-version }} on Ubuntu
     runs-on: ubuntu-latest
+    env:
+      YARN_GPG: no
+      npm_config_debug: yes
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,24 @@ jobs:
         path-to-lcov: ./lcov-js.info
         parallel: true
 
+    - name: "[Linux] Install lcov"
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo apt install lcov
+
+    - name: "[Linux] Generate C++ coverage"
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        lcov -c -d . --no-external -o lcov-cpp.info
+        lcov -r lcov-cpp.info "*/node_modules/*" -o lcov-cpp.info
+
+    - name: "[Linux] Send to Coveralls"
+      if: matrix.os == 'ubuntu-latest'
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: ./lcov-cpp.info
+        parallel: true
+
   end-coveralls:
     needs: build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
 
     name: Build node-${{ matrix.node-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      YARN_GPG: no
+      npm_config_debug: yes
 
     steps:
     - name: Checkout
@@ -32,45 +35,20 @@ jobs:
     - name: Run tests
       run: yarn test
 
-  coverage:
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x, 13.x]
-
-    name: Run coverage node-${{ matrix.node-version }}
-    runs-on: ubuntu-latest
-    env:
-      YARN_GPG: no
-      npm_config_debug: yes
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v1
-      with:
-        submodules: true
-
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-
-    - name: Install lcov
+    - name: "[Linux] Install lcov"
+      if: matrix.os == 'ubuntu-latest'
       run: sudo apt install lcov
 
-    - name: Install dependencies
-      run: yarn install --frozen-lockfile --ignore-scripts
-
-    - name: Build binaries
-      run: yarn node-pre-gyp configure build
-
-    - name: Generate coverage
+    - name: "[Linux] Generate coverage"
+      if: matrix.os == 'ubuntu-latest'
       run: |
         yarn nyc report --reporter=text-lcov > lcov-js.info
         lcov -c -d . --no-external -o lcov-cpp.info
         lcov -r lcov-cpp.info "*/node_modules/*" -o lcov-cpp.info
         lcov -a lcov-js.info -a lcov-cpp.info -o lcov.info
 
-    - name: Send to Coveralls
+    - name: "[Linux] Send to Coveralls"
+      if: matrix.os == 'ubuntu-latest'
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         parallel: true
 
   coverage-end:
-    needs: coverage
+    needs: build
 
     name: End Coveralls report
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ jobs:
 
     name: Build node-${{ matrix.node-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    env:
-      YARN_GPG: no
-      npm_config_debug: yes
 
     steps:
     - name: Checkout
@@ -35,22 +32,12 @@ jobs:
     - name: Run tests
       run: yarn test
 
-    - name: Generate coverage
-      run: yarn nyc report --reporter=text-lcov > lcov-js.info
-    
-    - name: Send to Coveralls
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: ./lcov-js.info
-        parallel: true
-
-  build-linux:
+  coverage:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 13.x]
 
-    name: Build node-${{ matrix.node-version }} on Ubuntu
+    name: Run coverage node-${{ matrix.node-version }}
     runs-on: ubuntu-latest
     env:
       YARN_GPG: no
@@ -67,32 +54,31 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - name: Install lcov
+      run: sudo apt install lcov
+
     - name: Install dependencies
       run: yarn install --frozen-lockfile --ignore-scripts
 
     - name: Build binaries
       run: yarn node-pre-gyp configure build
 
-    - name: Run tests
-      run: yarn test
-
-    - name: Install lcov
-      run: sudo apt install lcov
-
-    - name: Generate C++ coverage
+    - name: Generate coverage
       run: |
+        yarn nyc report --reporter=text-lcov > lcov-js.info
         lcov -c -d . --no-external -o lcov-cpp.info
         lcov -r lcov-cpp.info "*/node_modules/*" -o lcov-cpp.info
+        lcov -a lcov-js.info -a lcov-cpp.info -o lcov.info
 
     - name: Send to Coveralls
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: ./lcov-cpp.info
+        path-to-lcov: ./lcov.info
         parallel: true
 
-  end-coveralls:
-    needs: [build, build-linux]
+  coverage-end:
+    needs: coverage
 
     name: End Coveralls report
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
     - name: Install dependencies
       run: yarn install --frozen-lockfile
 
+    - name: Rebuild binaries
+      run: yarn node-pre-gyp rebuild
+
     - name: Run tests
       run: yarn test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       run: yarn install --frozen-lockfile --ignore-scripts
 
     - name: Build binaries
-      run: yarn node-pre-gyp build
+      run: yarn node-pre-gyp configure build
 
     - name: Run tests
       run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,18 +45,43 @@ jobs:
         path-to-lcov: ./lcov-js.info
         parallel: true
 
-    - name: "[Linux] Install lcov"
-      if: matrix.os == 'ubuntu-latest'
+  build-linux:
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 13.x]
+
+    name: Build node-${{ matrix.node-version }} on Ubuntu
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile --ignore-scripts
+
+    - name: Build binaries
+      run: yarn node-pre-gyp configure build
+
+    - name: Run tests
+      run: yarn test
+
+    - name: Install lcov
       run: sudo apt install lcov
 
-    - name: "[Linux] Generate C++ coverage"
-      if: matrix.os == 'ubuntu-latest'
+    - name: Generate C++ coverage
       run: |
         lcov -c -d . --no-external -o lcov-cpp.info
         lcov -r lcov-cpp.info "*/node_modules/*" -o lcov-cpp.info
 
-    - name: "[Linux] Send to Coveralls"
-      if: matrix.os == 'ubuntu-latest'
+    - name: Send to Coveralls
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -64,7 +89,7 @@ jobs:
         parallel: true
 
   end-coveralls:
-    needs: build
+    needs: [build, build-linux]
 
     name: End Coveralls report
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Install dependencies
-      run: yarn install --frozen-lockfile
+      run: yarn install --frozen-lockfile --ignore-scripts
 
-    - name: Rebuild binaries
-      run: yarn node-pre-gyp rebuild
+    - name: Build binaries
+      run: yarn node-pre-gyp build
 
     - name: Run tests
       run: yarn test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       run: yarn install --frozen-lockfile --ignore-scripts
 
     - name: Build artifacts
-      run: yarn node-pre-gyp build package
+      run: yarn node-pre-gyp configure build package
 
     - name: Upload to Release
       uses: csexton/release-asset-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,10 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Install dependencies
-      run: yarn install --frozen-lockfile
+      run: yarn install --frozen-lockfile --ignore-scripts
 
     - name: Build artifacts
-      run: yarn node-pre-gyp package
+      run: yarn node-pre-gyp build package
 
     - name: Upload to Release
       uses: csexton/release-asset-action@v2

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ license over Argon2 and the reference implementation.
 [opencollective-url]: https://opencollective.com/node-argon2
 [npm-image]: https://img.shields.io/npm/v/argon2.svg?style=flat-square
 [npm-url]: https://www.npmjs.com/package/argon2
-[actions-image]: https://img.shields.io/github/workflow/status/ranisalt/node-argon2/ci?style=flat-square
+[actions-image]: https://img.shields.io/github/workflow/status/ranisalt/node-argon2/CI?style=flat-square
 [actions-url]: https://github.com/ranisalt/node-argon2/actions
 [coverage-image]: https://img.shields.io/coveralls/github/ranisalt/node-argon2/master.svg?style=flat-square
 [coverage-url]: https://coveralls.io/github/ranisalt/node-argon2


### PR DESCRIPTION
Fix for coveralls. The coveralls results are on [https://coveralls.io/github/BjornLuG/node-argon2](https://coveralls.io/github/BjornLuG/node-argon2). I didnt upload the cpp lcov to coveralls since the `lcov` command is needed but not available nor easy to install on all OS. But it's still doable if needed.

Here's the snippet from the previous `.travis.yml` for cpp coverage:
```yml
after_success:
- nyc report --reporter=text-lcov > lcov-js.info
- lcov -c -d . --no-external -o lcov-cpp.info
- lcov -r lcov-cpp.info "*/node_modules/*" -o lcov-cpp.info
- lcov -a lcov-cpp.info -a lcov-js.info | coveralls
```

The file had declared the `lcov` apt package addon to install it but I'm not sure how this command was being used in the build matrix.
```yml
addons:
  apt:
    packages:
    - lcov
```

I guess we could just install lcov only on linux os and send it to coveralls (Only 3 will be sent of all the 9 builds). I'll try this later to see if it works.
2. 