### PR TITLE
Downgrade Ubuntu to 16.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,11 @@ jobs:
       run: yarn test
 
     - name: "[Linux] Install lcov"
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-16.04'
       run: sudo apt install lcov
 
     - name: "[Linux] Generate coverage"
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-16.04'
       run: |
         yarn nyc report --reporter=text-lcov > lcov-js.info
         lcov -c -d . --no-external -o lcov-cpp.info
@@ -48,7 +48,7 @@ jobs:
         lcov -a lcov-js.info -a lcov-cpp.info -o lcov.info
 
     - name: "[Linux] Send to Coveralls"
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-16.04'
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -59,7 +59,7 @@ jobs:
     needs: build
 
     name: End Coveralls report
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
 
     steps:
     - name: End Coveralls parallel job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       YARN_GPG: no
       npm_config_debug: yes
-      npm_config_build_from_source: yes
+      npm_config_build_from_source: true
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 13.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-16.04, macos-latest, windows-latest]
 
     name: Build node-${{ matrix.node-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     env:
       YARN_GPG: no
       npm_config_debug: yes
+      npm_config_build_from_source: yes
 
     steps:
     - name: Checkout
@@ -27,10 +28,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Install dependencies
-      run: yarn install --frozen-lockfile --ignore-scripts
-
-    - name: Build binaries
-      run: yarn node-pre-gyp configure build
+      run: yarn install --frozen-lockfile
 
     - name: Run tests
       run: yarn test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     name: Publish package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
 
     steps:
     - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 13.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-16.04, macos-latest, windows-latest]
 
     name: Build node-${{ matrix.node-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
     name: Build node-${{ matrix.node-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      npm_config_build_from_source: yes
+      npm_config_build_from_source: true
 
     steps:
     - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
 
     name: Build node-${{ matrix.node-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      npm_config_build_from_source: yes
 
     steps:
     - name: Checkout
@@ -49,10 +51,10 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Install dependencies
-      run: yarn install --frozen-lockfile --ignore-scripts
+      run: yarn install --frozen-lockfile
 
-    - name: Build artifacts
-      run: yarn node-pre-gyp configure build package
+    - name: Package artifacts
+      run: yarn node-pre-gyp package
 
     - name: Upload to Release
       uses: csexton/release-asset-action@v2

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ built per release using GitHub Actions.
 
 The current prebuilt binaries are built (and tested) with the following matrix:
 1. Node 10.x, 12.x, 13.x
-2. Ubuntu 18.04, Windows Server 2019, macOS Catalina 10.15
+2. Ubuntu 16.04, Windows Server 2019, macOS Catalina 10.15
 
 If your plaform is below the above requirements, you can follow the
 [Before Installing](#before-installing) section below to manually compile from
@@ -139,10 +139,16 @@ you'll need to specify that in the command.
 ### FAQ
 <details>
   <summary>How do I manually rebuild the binaries?</summary>
-  
+
   ```console
-  $ node-gyp rebuild -C ./node_modules/argon2
+  $ npx node-pre-gyp rebuild -C ./node_modules/argon2
   ```
+
+  > Run `node-pre-gyp` instead of `node-gyp` because node-argon2's `binding.gyp`
+  file relies on variables from `node-pre-gyp`.
+
+  > You can omit `npx` if you have a global installation of `node-pre-gyp`,
+  otherwise prefixing `npx` will use the local one in `./node_modules/.bin`
 </details>
 
 <details>
@@ -160,7 +166,7 @@ you'll need to specify that in the command.
   2. Ignore `node-argon2` install script and build manually.
   ```console
   $ npm install argon2 --ignore-scripts
-  $ node-gyp rebuild -C ./node_modules/argon2
+  $ npx node-pre-gyp rebuild -C ./node_modules/argon2
   ```
 </details>
 


### PR DESCRIPTION
This should resolve #244

I also:
1. Updated README to use `node-pre-gyp` instead of `node-gyp` for rebuilding binaries.
2. Updated actions to use `npm_config_build_from_source` flag to directly build instead of ignoring scripts completely. This will prevent potential issues if dependencies rely on some post-install scripts.