### PR TITLE
Change default hash function to argon2id

### DIFF
--- a/argon2.js
+++ b/argon2.js
@@ -13,7 +13,7 @@ const { deserialize, serialize } = require('@phc/format')
 const defaults = Object.freeze({
   hashLength: 32,
   saltLength: 16,
-  timeCost: 1,
+  timeCost: 3,
   memoryCost: 1 << 12,
   parallelism: 1,
   type: types.argon2id,

--- a/argon2.js
+++ b/argon2.js
@@ -13,10 +13,10 @@ const { deserialize, serialize } = require('@phc/format')
 const defaults = Object.freeze({
   hashLength: 32,
   saltLength: 16,
-  timeCost: 3,
+  timeCost: 1,
   memoryCost: 1 << 12,
   parallelism: 1,
-  type: types.argon2i,
+  type: types.argon2id,
   version
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -66,22 +66,22 @@ describe('Argon2', () => {
     })
 
     it('hash with null in password', async () => {
-      const hash = await argon2.hash('pass\0word', { salt })
+      const hash = await argon2.hash('pass\0word', { type: argon2id, salt })
       assert.equal(hashes.withNull, hash)
     })
 
     it('with raw hash, null in password', async () => {
-      const hash = await argon2.hash('pass\0word', { raw: true, salt })
+      const hash = await argon2.hash('pass\0word', { type: argon2id, raw: true, salt })
       assert(hashes.rawWithNull.equals(hash))
     })
 
     it('with associated data', async () => {
-      const hash = await argon2.hash(password, { associatedData, salt })
+      const hash = await argon2.hash(password, { type: argon2id, associatedData, salt })
       assert.equal(hashes.withAd, hash)
     })
 
     it('with secret', async () => {
-      const hash = await argon2.hash(password, { secret, salt })
+      const hash = await argon2.hash(password, { type: argon2id, secret, salt })
       assert.equal(hashes.withSecret, hash)
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -65,23 +65,23 @@ describe('Argon2', () => {
       assert(hashes.rawArgon2id.equals(hash))
     })
 
-    it('hash with null in password', async () => {
-      const hash = await argon2.hash('pass\0word', { type: argon2id, salt })
+    it('argon2i hash with null in password', async () => {
+      const hash = await argon2.hash('pass\0word', { type: argon2i, salt })
       assert.equal(hashes.withNull, hash)
     })
 
-    it('with raw hash, null in password', async () => {
-      const hash = await argon2.hash('pass\0word', { type: argon2id, raw: true, salt })
+    it('argon2i with raw hash, null in password', async () => {
+      const hash = await argon2.hash('pass\0word', { type: argon2i, raw: true, salt })
       assert(hashes.rawWithNull.equals(hash))
     })
 
-    it('with associated data', async () => {
-      const hash = await argon2.hash(password, { type: argon2id, associatedData, salt })
+    it('argon2i with associated data', async () => {
+      const hash = await argon2.hash(password, { type: argon2i, associatedData, salt })
       assert.equal(hashes.withAd, hash)
     })
 
-    it('with secret', async () => {
-      const hash = await argon2.hash(password, { type: argon2id, secret, salt })
+    it('argon2i with secret', async () => {
+      const hash = await argon2.hash(password, { type: argon2i, secret, salt })
       assert.equal(hashes.withSecret, hash)
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -36,12 +36,12 @@ describe('Argon2', () => {
 
   describe('hash', () => {
     it('hash with argon2i', async () => {
-      const hash = await argon2.hash(password, { salt })
+      const hash = await argon2.hash(password, { type: argon2i, salt })
       assert.equal(hashes.argon2i, hash)
     })
 
     it('argon2i with raw hash', async () => {
-      const hash = await argon2.hash(password, { raw: true, salt })
+      const hash = await argon2.hash(password, { type: argon2i, raw: true, salt })
       assert(hashes.rawArgon2i.equals(hash))
     })
 

--- a/test/test.js
+++ b/test/test.js
@@ -29,7 +29,7 @@ describe('Argon2', () => {
       timeCost: 3,
       memoryCost: 1 << 12,
       parallelism: 1,
-      type: argon2i,
+      type: argon2id,
       version: 0x13
     }, defaults)
   })


### PR DESCRIPTION
Change the default as recommended by the current IETF Draft:
https://tools.ietf.org/html/draft-irtf-cfrg-argon2-10


This fixes:
https://github.com/ranisalt/node-argon2/issues/252

