### PR TITLE
reduce default hashLength from 32 to 16

### DIFF
--- a/argon2.js
+++ b/argon2.js
@@ -11,7 +11,7 @@ const { hash: _hash, limits, types, names, version } = require(bindingPath) /* e
 const { deserialize, serialize } = require('@phc/format')
 
 const defaults = Object.freeze({
-  hashLength: 32,
+  hashLength: 16,
   saltLength: 16,
   timeCost: 3,
   memoryCost: 1 << 12,


### PR DESCRIPTION
https://github.com/P-H-C/phc-winner-argon2/blob/master/argon2-specs.pdf 
"Recommended parameters" section says "128 bits is sufficient for most applications, including key derivation. "
Also, https://crypto.stackexchange.com/a/39250/81624