### PR TITLE
Enforce C++17 on FreeBSD

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,7 +2,7 @@
   "target_defaults": {
     "include_dirs": ["argon2/include"],
     "target_conditions": [
-      ["OS == 'linux'", {
+      ["OS == 'linux' or OS == 'freebsd'", {
         "cflags_cc": ["-std=c++17"],
       }],
       ["OS == 'mac'", {


### PR DESCRIPTION
This fixes the build issue introduced in 9386c96c60ee.

The output before this commit:
```
gmake: Entering directory '/usr/home/khng/.config/yarn/global/node_modules/argon2/build'
  CC(target) Release/obj.target/libargon2/argon2/src/opt.o
  CC(target) Release/obj.target/libargon2/argon2/src/argon2.o
  CC(target) Release/obj.target/libargon2/argon2/src/core.o
  CC(target) Release/obj.target/libargon2/argon2/src/blake2/blake2b.o
  CC(target) Release/obj.target/libargon2/argon2/src/thread.o
  CC(target) Release/obj.target/libargon2/argon2/src/encoding.o
  AR(target) Release/obj.target/argon2.a
  COPY Release/argon2.a
  CXX(target) Release/obj.target/argon2/src/argon2_node.o
../src/argon2_node.cpp:52:21: error: assigning to 'uint8_t *' (aka 'unsigned char *') from 'const std::basic_string<unsigned char>::value_type *' (aka 'const unsigned char *') discards qualifiers
    ctx.pwd = plain.data();
              ~~~~~~^~~~~~
../src/argon2_node.cpp:54:21: error: assigning to 'uint8_t *' (aka 'unsigned char *') from 'const std::basic_string<unsigned char>::value_type *' (aka 'const unsigned char *') discards qualifiers
    ctx.salt = salt.data();
               ~~~~~^~~~~~
../src/argon2_node.cpp:56:18: error: assigning to 'uint8_t *' (aka 'unsigned char *') from 'const std::basic_string<unsigned char>::value_type *' (aka 'const unsigned char *') discards qualifiers
    ctx.secret = opts.secret.empty() ? nullptr : opts.secret.data();
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/argon2_node.cpp:58:14: error: assigning to 'uint8_t *' (aka 'unsigned char *') from 'const std::basic_string<unsigned char>::value_type *' (aka 'const unsigned char *') discards qualifiers
    ctx.ad = opts.ad.empty() ? nullptr : opts.ad.data();
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/argon2_node.cpp:159:29: warning: implicit conversion from 'unsigned long' to 'uint32_t' (aka 'unsigned int') changes value from 4294967296 to 0 [-Wconstant-conversion]
    setMaxMin("memoryCost", ARGON2_MAX_MEMORY, max(ARGON2_MIN_MEMORY, 1024));
    ~~~~~~~~~               ^~~~~~~~~~~~~~~~~
../src/../argon2/include/argon2.h:68:50: note: expanded from macro 'ARGON2_MAX_MEMORY'
    ARGON2_MIN(UINT32_C(0xFFFFFFFF), UINT64_C(1) << ARGON2_MAX_MEMORY_BITS)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
../src/../argon2/include/argon2.h:63:46: note: expanded from macro 'ARGON2_MIN'
#define ARGON2_MIN(a, b) ((a) < (b) ? (a) : (b))
                                             ^
1 warning and 4 errors generated.
gmake: *** [argon2.target.mk:117: Release/obj.target/argon2/src/argon2_node.o] Error 1
gmake: Leaving directory '/usr/home/khng/.config/yarn/global/node_modules/argon2/build'
gyp ERR! build error
gyp ERR! stack Error: `gmake` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:194:23)
gyp ERR! stack     at ChildProcess.emit (events.js:400:28)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:282:12)
gyp ERR! System FreeBSD 13.0-STABLE
gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "build" "--fallback-to-build" "--module=/usr/home/khng/.config/yarn/global/node_modules/argon2/lib/binding/napi-v3/argon2.node" "--module_name=argon2" "--module_path=/usr/home/khng/.config/yarn/global/node_modules/argon2/lib/binding/napi-v3" "--napi_version=8" "--node_abi_napi=napi" "--napi_build_version=3" "--node_napi_label=napi-v3"
gyp ERR! cwd /usr/home/khng/.config/yarn/global/node_modules/argon2
gyp ERR! node -v v14.18.1
gyp ERR! node-gyp -v v5.1.0
gyp ERR! not ok
node-pre-gyp ERR! build error
node-pre-gyp ERR! stack Error: Failed to execute '/usr/local/bin/node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build --module=/usr/home/khng/.config/yarn/global/node_modules/argon2/lib/binding/napi-v3/argon2.node --module_name=argon2 --module_path=/usr/home/khng/.config/yarn/global/node_modules/argon2/lib/binding/napi-v3 --napi_version=8 --node_abi_napi=napi --napi_build_version=3 --node_napi_label=napi-v3' (1)
node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/usr/home/khng/.config/yarn/global/node_modules/@mapbox/node-pre-gyp/lib/util/compile.js:89:23)
node-pre-gyp ERR! stack     at ChildProcess.emit (events.js:400:28)
node-pre-gyp ERR! stack     at maybeClose (internal/child_process.js:1058:16)
node-pre-gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:293:5)
node-pre-gyp ERR! System FreeBSD 13.0-STABLE
```