### PR TITLE
Fixed bug where a different algorithm throws

### DIFF
--- a/argon2.js
+++ b/argon2.js
@@ -81,13 +81,19 @@ const needsRehash = (digest, options) => {
 };
 
 const verify = async (digest, plain, options) => {
+  const obj = deserialize(digest);
+  // Only these have the "params" key, so if the password was encoded
+  // using any other method, the destructuring throws an error
+  if (!['argon2i', 'argon2d', 'argon2id'].includes(obj.id)) {
+    return false; 
+  }
   const {
     id,
     version = 0x10,
     params: { m, t, p, data },
     salt,
     hash,
-  } = deserialize(digest);
+  } = obj;
 
   return timingSafeEqual(
     await bindingsHash(Buffer.from(plain), salt, {

--- a/argon2.js
+++ b/argon2.js
@@ -84,7 +84,7 @@ const verify = async (digest, plain, options) => {
   const obj = deserialize(digest);
   // Only these have the "params" key, so if the password was encoded
   // using any other method, the destructuring throws an error
-  if (!['argon2i', 'argon2d', 'argon2id'].includes(obj.id)) {
+  if (!(obj.id in types)) {
     return false; 
   }
 

--- a/argon2.js
+++ b/argon2.js
@@ -87,6 +87,7 @@ const verify = async (digest, plain, options) => {
   if (!['argon2i', 'argon2d', 'argon2id'].includes(obj.id)) {
     return false; 
   }
+
   const {
     id,
     version = 0x10,


### PR DESCRIPTION
If trying to check the password with a string that was encoded using a different algorithm, the script will correctly deserialize but then fail to destructure `params: { m, t, p, data }` as seen in this bug:

```
TypeError: Cannot read property 'm' of undefined
    at Object.verify ([PATH]/node_modules/argon2/argon2.js:57:41)
    at file://[PATH]/src/register.js:72:35
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
    at async [PATH]/node_modules/server/src/join/index.js:47:23
    at async [PATH]/node_modules/server/router/generic.js:28:5
    at async Object.middle ([PATH]/node_modules/server/src/join/index.js:47:23) {
  code: '',
  params: [Object: null prototype] { '0': '' }
}
```

With this PR I'd like to start a conversation on how to fix it, my proposal is to check for the algorithm used but we could also just check if `params` is there, or give `params` a default alternatively.

Repro:

```js
const argon2 = require("argon2");
await argon2.verify(
  "$2a$12$0.tfCfdkhRon.ZeYbTxbfOuyoP547V0TxxM/eL5nTyPSPE8MEpIwW",
  "123456"
);
// Throws error, when it's expected to return "false"
```

Edit: note that [Codacity is complaining about semicolons](https://app.codacy.com/gh/ranisalt/node-argon2/pullRequest?prid=8880242) but the rest of the project uses them...