### PR TITLE
Rollback node-pre-gyp binary config

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
   "binary": {
     "module_name": "argon2",
     "module_path": "./lib/binding/napi-v{napi_build_version}",
-    "host": "https://github.com",
-    "remote_path": "./ranisalt/node-argon2/releases/download/v{version}",
+    "host": "https://github.com/ranisalt/node-argon2/releases/download/",
+    "remote_path": "v{version}",
     "package_name": "{module_name}-v{version}-napi-v{napi_build_version}-{platform}-{arch}-{libc}.tar.gz",
     "napi_versions": [
       3


### PR DESCRIPTION
Make environment variable `npm_config_argon2_binary_host_mirror` or command line `--argon2_binary_host_mirror` could work.

Fix #370