### PR TITLE
TS: make raw option in hash function optional

### DIFF
--- a/argon2.d.ts
+++ b/argon2.d.ts
@@ -36,7 +36,7 @@ export const defaults: Options;
 export const limits: OptionLimits;
 export function hash(
   plain: Buffer | string,
-  options: Options & { raw: true }
+  options: Options & { raw?: true }
 ): Promise<Buffer>;
 export function hash(
   plain: Buffer | string,


### PR DESCRIPTION
When specifying options in the hash function, one is always forced by the Typescript type checker to provide an object with { raw: true }. 

Using this wrapper inside pure JS causes no trouble: when no `raw` key is specified inside the options object, the function returns a string, otherwise (with { raw: true }) the hash function returns a Buffer instead.