### PR TITLE
Fix: Add missing properties and correct types in Options typedef

### DIFF
--- a/argon2.cjs
+++ b/argon2.cjs
@@ -55,6 +55,7 @@ module.exports.limits = limits;
  * @property {Buffer} [salt]
  * @property {Buffer} [associatedData]
  * @property {Buffer} [secret]
+ * @property {number} [saltLength]
  */
 
 /**


### PR DESCRIPTION
## Issue
- close #403

## Remarks
- `saltLength` no longer exists 
  - added to JSdoc Options
- the type of `salt` is `any | undefined` instead of `Buffer | undefined` 
  - is generated correctly when I run `tsc` (`npm run prepare`)
- the type of `associatedData` is `any | undefined` instead of `Buffer | undefined`
  - is generated correctly when I run `tsc` (`npm run prepare`)
- the type of `secret` is `any | undefined` instead of `Buffer | undefined`
  - is generated correctly when I run `tsc` (`npm run prepare`)
  
 ## Generated type
```ts
// argon2.d.cts
export type Options = {
    hashLength?: number | undefined;
    timeCost?: number | undefined;
    memoryCost?: number | undefined;
    parallelism?: number | undefined;
    type?: 0 | 2 | 1 | undefined;
    version?: number | undefined;
    salt?: Buffer | undefined;
    associatedData?: Buffer | undefined;
    secret?: Buffer | undefined;
    saltLength?: number | undefined;
};
```