### PR TITLE
Disable LTO to avoid missing symbols in some envs

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -20,7 +20,7 @@
       "Release": {
         "target_conditions": [
           ["OS != 'win'", {
-            "cflags+": ["-fdata-sections", "-ffunction-sections", "-flto", "-fvisibility=hidden"],
+            "cflags+": ["-fdata-sections", "-ffunction-sections", "-fvisibility=hidden"],
             "ldflags+": ["-Wl,--gc-sections"]
           }]
         ],


### PR DESCRIPTION
LTO may not always work correctly, for whatever reason, resulting in e.g.

> node_modules/argon2/build/Release/argon2.node: undefined symbol: argon2_ctx

Removing LTO seems to be fine, and resolves the above issue.