### PR TITLE
Avoid overriding _FORTIFY_SOURCE if already set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,3 +133,26 @@ jobs:
             npm ci
             npm test
           sync: sshfs
+
+  build-with-fortify-source:
+    strategy:
+      matrix:
+        cppflags: ['', '-D _FORTIFY_SOURCE=2', '-D _FORTIFY_SOURCE=3', '-D_FORTIFY_SOURCE=2', '-D_FORTIFY_SOURCE=3']
+
+    name: Test that setting _FORTIFY_SOURCE will not break the build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          cache: npm
+          node-version: 22
+
+      - name: Install
+        run: CPPFLAGS="${{ matrix.cppflags }}" npm ci

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+  "variables": {
+    "fortify_source_defined": "<!(node -p \"/-D\\s*_FORTIFY_SOURCE=/.test((process.env.CFLAGS || '') + (process.env.CPPFLAGS || '') + (process.env.CXXFLAGS || ''))\")",
+  },
   "target_defaults": {
     "include_dirs": ["argon2/include"],
     "target_conditions": [
@@ -19,9 +22,11 @@
     "configurations": {
       "Release": {
         "target_conditions": [
+          # Define _FORTIFY_SOURCE on non-Darwin, but avoid overriding it if already set
           ["OS not in 'ios mac'", {
-            # Avoid defining _FORTIFY_SOURCE on Darwin
-            "defines+": ["_FORTIFY_SOURCE=2"]
+            "conditions": [
+              ["fortify_source_defined=='false'", {"defines+": ["_FORTIFY_SOURCE=2"]}]
+            ]
           }],
           ["OS not in 'win ios mac aix'", {
             # On Darwin with Xcode CLT/LLVM, "-fvisibility=hidden" hide all symbols that


### PR DESCRIPTION
If the environment defines flags other than `_FORTIFY_SOURCE=2` (e.g. on Arch Linux, which sets it to 3), compilation fails because the flag cannot be re-defined.

```
make: Entering directory '/tmp/node-argon2/build'
  CC(target) Release/obj.target/libargon2/argon2/src/opt.o
<command-line>: warning: "_FORTIFY_SOURCE" redefined
<command-line>: note: this is the location of the previous definition
  CC(target) Release/obj.target/libargon2/argon2/src/argon2.o
<command-line>: warning: "_FORTIFY_SOURCE" redefined
<command-line>: note: this is the location of the previous definition
  CC(target) Release/obj.target/libargon2/argon2/src/blake2/blake2b.o
<command-line>: warning: "_FORTIFY_SOURCE" redefined
<command-line>: note: this is the location of the previous definition
  CC(target) Release/obj.target/libargon2/argon2/src/core.o
<command-line>: warning: "_FORTIFY_SOURCE" redefined
<command-line>: note: this is the location of the previous definition
  CC(target) Release/obj.target/libargon2/argon2/src/encoding.o
<command-line>: warning: "_FORTIFY_SOURCE" redefined
<command-line>: note: this is the location of the previous definition
  CC(target) Release/obj.target/libargon2/argon2/src/thread.o
<command-line>: warning: "_FORTIFY_SOURCE" redefined
<command-line>: note: this is the location of the previous definition
rm -f Release/obj.target/argon2.a Release/obj.target/argon2.a.ar-file-list; mkdir -p `dirname Release/obj.target/argon2.a`
ar crs Release/obj.target/argon2.a @Release/obj.target/argon2.a.ar-file-list
  COPY Release/argon2.a
  CXX(target) Release/obj.target/argon2/argon2.o
<command-line>: error: "_FORTIFY_SOURCE" redefined [-Werror]
<command-line>: note: this is the location of the previous definition
cc1plus: all warnings being treated as errors
make: *** [argon2.target.mk:138: Release/obj.target/argon2/argon2.o] Error 1
make: Leaving directory '/tmp/node-argon2/build'
```

By only setting it conditionally, we can avoid this issue.

Fixes #454.