### PR TITLE
Potential fix for code scanning alert no. 35: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   lint:


### PR DESCRIPTION
Potential fix for [https://github.com/ranisalt/node-argon2/security/code-scanning/35](https://github.com/ranisalt/node-argon2/security/code-scanning/35)

To resolve the issue, we need to add a `permissions` block to the workflow. This block should explicitly define the minimal permissions required for each job or at the workflow level. Since the jobs primarily involve linting, testing, and coverage reporting, the `contents: read` permission is sufficient for most cases. For the `coverage` job, which uses a secret (`CODACY_PROJECT_TOKEN`), we need to ensure permissions are adequate for secret usage.

The permissions block will be added at the workflow root so that all jobs inherit the specified permissions unless overridden. This approach minimizes repetition and ensures uniform security settings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
