### PR TITLE
Fix compilation on solaris

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -39,7 +39,7 @@
               ["fortify_source_defined=='false'", {"defines+": ["_FORTIFY_SOURCE=2"]}]
             ]
           }],
-          ["OS not in 'win ios mac aix'", {
+          ["OS not in 'win ios mac aix solaris'", {
             # On Darwin with Xcode CLT/LLVM, "-fvisibility=hidden" hide all symbols that
             # not explicitly marked with __attribute__((visibility("default")))
             # Flags for sections are specific to ELF binaries


### PR DESCRIPTION
When compiling on omnios (illumos distribution, descendent of solaris), I received this error because illumos `ld` does not support `--gc-sections`.

```
ld: fatal: unrecognized option '--gc-sections'
```

Building with this patch worked as expected.